### PR TITLE
Update README -- add prerequisites, Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatte
 
 ### Windows
 
-Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users should manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-on-windows).
+Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users can instead manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-on-windows).  Alternatively, you can run the script using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about).
 
 ## Regula rules
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ useful if you have several versions installed:
 
     env TERRAFORM=terraform-v0.12.18 ./bin/regula ../regula-ci-example/ lib
 
+Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatted plan.
+
 ### Windows
 
 Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users should manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-windows).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ The second part is a Rego framework that:
 
 ## Running Regula locally
 
+Install the prerequisites:
+
+- [OPA](https://www.openpolicyagent.org/docs/latest/#1-download-opa)
+- [Terraform 0.12+](https://www.terraform.io/downloads.html)
+
+### macOS and Linux
+
+Run the following command:
+
     ./bin/regula [TERRAFORM_PATH] [REGO_PATHS...]
 
 `TERRAFORM_PATH` is the directory where your Terraform configuration files are
@@ -68,6 +77,10 @@ It is also possible to set the name of the `terraform` executable, which is
 useful if you have several versions installed:
 
     env TERRAFORM=terraform-v0.12.18 ./bin/regula ../regula-ci-example/ lib
+
+### Windows
+
+Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users should manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-windows).
 
 ## Regula rules
 
@@ -348,7 +361,7 @@ example.
 
 ### Locally producing a report
 
-In some cases, you may want to produce the steps that Regula performs manually.
+In some cases (such as development and testing), you may want to manually reproduce the steps that Regula performs automatically.
 If that is something you want to step through, this section is for you.
 
 We first need to obtain a JSON-formatted terraform plan.  In order to do get
@@ -369,6 +382,26 @@ Or using `fregot`:
     fregot eval --input input.json 'data.fugue.regula.report' . | jq
 
 If all goes well, you should now see the results for each rule.
+
+### Locally producing a report -- Windows
+
+To locally produce a Regula report on Windows, take the following steps:
+
+1.  Generate a JSON-based terraform plan:
+
+    ```
+    .\terraform.exe init .\regula-ci-example
+    .\terraform.exe plan -refresh=false -out=infra .\regula-ci-example
+    .\terraform.exe show -json infra >infra.json
+    ```
+
+2. Run OPA against this input file:
+
+    ```
+    .\opa_windows_amd64.exe eval -i .\infra.json -d .\regula\lib\ -d .\regula\rules\ 'data.fugue.regula.report'
+    ```
+
+
 
 [opa]: https://www.openpolicyagent.org/
 [fregot]: https://github.com/fugue/fregot

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ If all goes well, you should now see the results for each rule.
 
 ### Locally producing a report -- Windows
 
-To locally produce a Regula report on Windows, take the following steps:
+To locally produce a Regula report on Windows, take the following steps and replace `.\regula-ci-example` with the directory containing your Terraform:
 
 1.  Generate a JSON-based terraform plan:
 
@@ -402,8 +402,6 @@ To locally produce a Regula report on Windows, take the following steps:
     ```
     .\opa_windows_amd64.exe eval -i .\infra.json -d .\regula\lib\ -d .\regula\rules\ 'data.fugue.regula.report'
     ```
-
-
 
 [opa]: https://www.openpolicyagent.org/
 [fregot]: https://github.com/fugue/fregot

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     -   [Adding a test](#adding-a-test)
     -   [Debugging a rule with fregot](#debugging-a-rule-with-fregot)
     -   [Locally producing a report](#locally-producing-a-report)
+    -   [Locally producing a report on Windows](#locally-producing-a-report-on-windows)
 
 ## Introduction
 
@@ -82,7 +83,7 @@ Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatte
 
 ### Windows
 
-Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users should manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-windows).
+Because Regula uses a bash script to automatically generate a plan, convert it to JSON, and run the Rego validations, Windows users should manually run the steps that Regula performs. See those steps [here](#locally-producing-a-report-on-windows).
 
 ## Regula rules
 
@@ -385,7 +386,7 @@ Or using `fregot`:
 
 If all goes well, you should now see the results for each rule.
 
-### Locally producing a report -- Windows
+### Locally producing a report on Windows
 
 To locally produce a Regula report on Windows, take the following steps and replace `.\regula-ci-example` with the directory containing your Terraform:
 


### PR DESCRIPTION
This PR updates the README to add prerequisites (downloading/installing OPA, Terraform 0.12+) and Windows commands.