### PR TITLE
Conftest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,19 +348,7 @@ To use Regula with Conftest:
 
     And of course you can pull in your own Regula rules as well.
 
-3.  We'll add a policy file that simply forwards messages from the
-    `regula.conftest` integration.
-
-        # policy/regula.rego
-        package main
-
-        import data.fugue.regula.conftest as regula
-
-        deny[msg] {
-          regula.deny[msg]
-        }
-
-4.  As this point, it's simply a matter of running conftest!
+3.  As this point, it's simply a matter of running conftest!
 
         conftest test plan.json
 

--- a/README.md
+++ b/README.md
@@ -336,11 +336,17 @@ To use Regula with Conftest:
         terraform plan -refresh=false -out=plan.tfplan
         terraform show -json plan.tfplan >plan.json
 
-2.  Now, we'll pull the Regula library (and optionally rules) into the policy
-    directory:
+2.  Now, we'll pull the conftest support for Regula and the Regula library in.
 
+        conftest pull -p policy/ github.com/fugue/regula/conftest
         conftest pull -p policy/regula/lib github.com/fugue/regula/lib
+
+    If we want to use the [rules](#rule-library) that come with regula, we can
+    use:
+
         conftest pull -p policy/regula/rules github.com/fugue/regula/rules
+
+    And of course you can pull in your own Regula rules as well.
 
 3.  We'll add a policy file that simply forwards messages from the
     `regula.conftest` integration.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ To use Regula with Conftest:
 
 4.  As this point, it's simply a matter of running conftest!
 
-        conftest test input.json
+        conftest test plan.json
 
 ## Development
 

--- a/conftest/regula.rego
+++ b/conftest/regula.rego
@@ -1,5 +1,5 @@
 # Conftest integration package for Regula.
-package fugue.regula.conftest
+package main
 
 import data.fugue.regula
 

--- a/lib/fugue_regula_conftest.rego
+++ b/lib/fugue_regula_conftest.rego
@@ -1,0 +1,17 @@
+# Conftest integration package for Regula.
+package fugue.regula.conftest
+
+import data.fugue.regula
+
+deny[msg] {
+  # Our information comes from the report.  We select all invalid resources
+  # and will generate a deny message for each of them.
+  regula.report.rules[rule_name].resources[resource_name].valid == false
+
+  # Generate a message for each invalid resource.
+  #
+  # Since we have more information available in the report; we should look
+  # into whether or not we can use conftests's structured output.
+  msg = sprintf("regula: rule %s failed for resource %s",
+         [rule_name, resource_name])
+}


### PR DESCRIPTION
Add a small conftest integration library and document how to use conftest together with Regula.

Note that the instructions in the README currently do not work since these changes are not on `master` yet, so the following pull URLs need to be used instead:
    
    conftest pull -p policy/regula/lib 'git@github.com:fugue/regula.git//lib?ref=conftest'
    conftest pull -p policy/regula/rules 'git@github.com:fugue/regula.git//rules?ref=conftest'