### PR TITLE
Custom error messages support

### DIFF
--- a/conftest/regula.rego
+++ b/conftest/regula.rego
@@ -6,12 +6,15 @@ import data.fugue.regula
 deny[msg] {
   # Our information comes from the report.  We select all invalid resources
   # and will generate a deny message for each of them.
-  regula.report.rules[rule_name].resources[resource_name].valid == false
+  resource = regula.report.rules[rule_name].resources[resource_name]
+  resource.valid == false
 
   # Generate a message for each invalid resource.
   #
   # Since we have more information available in the report; we should look
   # into whether or not we can use conftests's structured output.
-  msg = sprintf("regula: rule %s failed for resource %s",
-         [rule_name, resource_name])
+  msg = concat(": ", [
+    "regula",
+    regula.report_rule_message(rule_name, resource_name, resource.message)
+  ])
 }

--- a/examples/aws/tag_all_resources.rego
+++ b/examples/aws/tag_all_resources.rego
@@ -60,18 +60,20 @@ is_tagged(resource) {
   resource.tags[_] = _
 }
 
-is_improperly_tagged(resource) {
+is_improperly_tagged(resource) = msg {
   # Any tag value has less than 6 characters.
-  count(resource.tags[_]) < 6
-} {
+  resource.tags[key] = val
+  count(val) < 6
+  msg = sprintf("Tag %s is too short", [key])
+} else = "No tags found" {
   # The resource is not tagged at all.
   not is_tagged(resource)
 }
 
 policy[r] {
    resource = taggable_resources[_]
-   is_improperly_tagged(resource)
-   r = fugue.deny_resource(resource)
+   msg = is_improperly_tagged(resource)
+   r = fugue.deny_resource_with_message(resource, msg)
 } {
    resource = taggable_resources[_]
    not is_improperly_tagged(resource)

--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -31,19 +31,27 @@ allow_resource(resource) = ret {
 }
 
 deny_resource(resource) = ret {
+  ret = deny_resource_with_message(resource, "invalid")
+}
+
+deny_resource_with_message(resource, message) = ret {
   ret = {
     "valid": false,
     "id": resource.id,
-    "message": "invalid",
+    "message": message,
     "type": resource._type
   }
 }
 
 missing_resource(resource_type) = ret {
+  ret = missing_resource_with_message(resource_type, "invalid")
+}
+
+missing_resource_with_message(resource_type, message) = ret {
   ret = {
     "valid": false,
     "id": "",
-    "message": "invalid",
+    "message": message,
     "type": resource_type
   }
 }

--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -31,7 +31,7 @@ allow_resource(resource) = ret {
 }
 
 deny_resource(resource) = ret {
-  ret = deny_resource_with_message(resource, "invalid")
+  ret = deny_resource_with_message(resource, "")
 }
 
 deny_resource_with_message(resource, message) = ret {
@@ -44,7 +44,7 @@ deny_resource_with_message(resource, message) = ret {
 }
 
 missing_resource(resource_type) = ret {
-  ret = missing_resource_with_message(resource_type, "invalid")
+  ret = missing_resource_with_message(resource_type, "")
 }
 
 missing_resource_with_message(resource_type, message) = ret {

--- a/lib/fugue_regula.rego
+++ b/lib/fugue_regula.rego
@@ -162,16 +162,26 @@ report_message(summary, rule_results) = ret {
     sprintf("%d controls passed, %d controls failed\n",
       [summary.controls_passed, summary.controls_failed]),
     concat("", [msg |
-      rule_results[rule_name].resources[resource_name].valid == false
-      msg = report_rule_message(rule_name, resource_name)
+      resource_result = rule_results[rule_name].resources[resource_name]
+      resource_result.valid == false
+      msg = report_rule_message(
+        rule_name, resource_name, resource_result.message)
     ])
   ])
 }
 
 # Generate a textual message for a single failure.
-report_rule_message(rule_name, resource_name) = ret {
+report_rule_message(rule_name, resource_name, message) = ret {
   resource_name = ""
+  message = ""
   ret = sprintf("Rule %s failed\n", [rule_name])
 } else = ret {
+  resource_name = ""
+  ret = sprintf("Rule %s failed: %s\n", [rule_name, message])
+} else = ret {
+  message = ""
   ret = sprintf("Rule %s failed for resource %s\n", [rule_name, resource_name])
+} else = ret {
+  ret = sprintf("Rule %s failed for resource %s: %s\n",
+    [rule_name, resource_name, message])
 }

--- a/tests/examples/aws/inputs/tag_all_resources_infra.rego
+++ b/tests/examples/aws/inputs/tag_all_resources_infra.rego
@@ -24,6 +24,7 @@ mock_input = {
             "bucket_prefix": null,
             "cors_rule": [],
             "force_destroy": false,
+            "grant": [],
             "lifecycle_rule": [],
             "logging": [],
             "object_lock_configuration": [],
@@ -52,6 +53,21 @@ mock_input = {
             "tags": {
               "Name": "12345"
             }
+          }
+        },
+        {
+          "address": "aws_vpc.untagged",
+          "mode": "managed",
+          "type": "aws_vpc",
+          "name": "untagged",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "enable_dns_support": true,
+            "instance_tenancy": "default",
+            "tags": null
           }
         },
         {
@@ -92,6 +108,7 @@ mock_input = {
           "bucket_prefix": null,
           "cors_rule": [],
           "force_destroy": false,
+          "grant": [],
           "lifecycle_rule": [],
           "logging": [],
           "object_lock_configuration": [],
@@ -110,6 +127,7 @@ mock_input = {
           "bucket_domain_name": true,
           "bucket_regional_domain_name": true,
           "cors_rule": [],
+          "grant": [],
           "hosted_zone_id": true,
           "id": true,
           "lifecycle_rule": [],
@@ -162,6 +180,41 @@ mock_input = {
           "main_route_table_id": true,
           "owner_id": true,
           "tags": {}
+        }
+      }
+    },
+    {
+      "address": "aws_vpc.untagged",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "untagged",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "assign_generated_ipv6_cidr_block": false,
+          "cidr_block": "10.0.0.0/16",
+          "enable_dns_support": true,
+          "instance_tenancy": "default",
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "default_network_acl_id": true,
+          "default_route_table_id": true,
+          "default_security_group_id": true,
+          "dhcp_options_id": true,
+          "enable_classiclink": true,
+          "enable_classiclink_dns_support": true,
+          "enable_dns_hostnames": true,
+          "id": true,
+          "ipv6_association_id": true,
+          "ipv6_cidr_block": true,
+          "main_route_table_id": true,
+          "owner_id": true
         }
       }
     },
@@ -253,6 +306,19 @@ mock_input = {
               "constant_value": {
                 "Name": "12345"
               }
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_vpc.untagged",
+          "mode": "managed",
+          "type": "aws_vpc",
+          "name": "untagged",
+          "provider_config_key": "aws",
+          "expressions": {
+            "cidr_block": {
+              "constant_value": "10.0.0.0/16"
             }
           },
           "schema_version": 1

--- a/tests/examples/aws/inputs/tag_all_resources_infra.tf
+++ b/tests/examples/aws/inputs/tag_all_resources_infra.tf
@@ -26,3 +26,7 @@ resource "aws_s3_bucket" "invalid" {
     Environment = "Dev"
   }
 }
+
+resource "aws_vpc" "untagged" {
+  cidr_block       = "10.0.0.0/16"
+}

--- a/tests/examples/aws/tag_all_resources_test.rego
+++ b/tests/examples/aws/tag_all_resources_test.rego
@@ -5,7 +5,15 @@ import data.fugue.regula
 test_tag_all_resources {
   report := regula.report with input as mock_input
   resources := report.rules.tag_all_resources.resources
+
   resources["aws_vpc.invalid"].valid == false
+  re_match("too short", resources["aws_s3_bucket.invalid"].message)
+
   resources["aws_s3_bucket.invalid"].valid == false
+  re_match("too short", resources["aws_s3_bucket.invalid"].message)
+
+  resources["aws_vpc.untagged"].valid == false
+  re_match("No tags", resources["aws_vpc.untagged"].message)
+
   resources["aws_vpc.valid"].valid == true
 }


### PR DESCRIPTION
This adds support for `fugue.deny_resource_with_message` and
`fugue.missing_resource_with_message`, which will soon be supported
in Fugue.

The custom error messages are included in the JSON output,
human-readable output and conftest output.