### PR TITLE
Better report testing

### DIFF
--- a/tests/lib/fugue_regula_report_test.rego
+++ b/tests/lib/fugue_regula_report_test.rego
@@ -1,0 +1,48 @@
+# This is a larger test case that mocks the whole `data.rules` tree as well
+# as the `input`.
+package fugue.regula_report_test
+
+import data.fugue.regula
+import data.tests.rules.ebs_volume_encrypted
+
+# We reuse the mock input from another test case.
+mock_input = ebs_volume_encrypted.mock_input
+
+# We construct some mock rules as well.
+mock_rules = {
+  "always_pass": {
+    "controls": {"MOCK_1.2.3"},
+    "resource_type": "aws_ebs_volume",
+    "allow": true
+  },
+  "always_fail": {
+    "resource_type": "aws_ebs_volume",
+    "deny": true
+  }
+}
+
+# Produce a report.
+report = ret {
+  ret = regula.report with input as mock_input with data.rules as mock_rules
+}
+
+# Test the report.
+test_report {
+  report.summary == {
+    "controls_failed": 0,
+    "controls_passed": 1,
+    "rules_failed": 1,
+    "rules_passed": 1,
+    "valid": false,
+  }
+
+  report.controls == {
+    "MOCK_1.2.3": {
+      "rules": {"always_pass"},
+      "valid": true,
+    }
+  }
+
+  re_match("1 rules passed, 1 rules failed", report.message)
+  re_match("Rule always_fail failed for resource", report.message)
+}

--- a/tests/lib/fugue_regula_test.rego
+++ b/tests/lib/fugue_regula_test.rego
@@ -45,24 +45,3 @@ test_judgement_from_allow_denies_08 {
   j = judgement_from_allow_denies(testutil_resource, [false], [true])
   not j.valid
 }
-
-# Note that when this tests is run, `data.rules[_]` will contain all rules in
-# the rules directory as well as the examples. This makes the output of the test
-# report extremely volatile.
-#
-# We should try and fix this by using a with data.rules clause but
-# unfortunately, that isn't supported in fregot yet:
-#
-# <https://github.com/fugue/fregot/issues/178>
-#
-# For now, we just check the "shape" of the report instead.
-test_report {
-  r = report
-  is_object(r.rules)
-  is_object(r.controls)
-  is_number(r.summary.rules_failed)
-  is_number(r.summary.rules_passed)
-  is_number(r.summary.controls_failed)
-  is_number(r.summary.controls_passed)
-  is_string(r.message)
-}


### PR DESCRIPTION
Adds a test that uses `with data.rules ...` to mock the rules as well
as the input.  This gives us much better coverage.  Requires
<https://github.com/fugue/fregot/issues/178> for running this with
`fregot`.