### PR TITLE
enable structured output for conftest

### DIFF
--- a/conftest/regula.rego
+++ b/conftest/regula.rego
@@ -3,7 +3,7 @@ package main
 
 import data.fugue.regula
 
-deny[msg] {
+deny[{"msg": msg, "rule_name": rule_name, "resource": resource_name}] {
   # Our information comes from the report.  We select all invalid resources
   # and will generate a deny message for each of them.
   resource = regula.report.rules[rule_name].resources[resource_name]


### PR DESCRIPTION
This PR enables structured output for conftest and includes the rule_name and resource in the JSON output. This is really valuable to us, as we're looking to do some post-processing on the output.

conftest's stdout, tap, table, and junit output remains unchanged. conftest's json output, however, now looks like this:

```json
[
        {
                "filename": "policy/test_inputs/new_tagging_standard_infra-plan.json",
                "warnings": [],
                "failures": [
                        {
                                "msg": "regula: Rule new_tagging_standard failed for resource aws_instance.fail_no_tags: Resource is taggable but has no tags (or ASG tags not set to propagate at launch)\n",
                                "metadata": {
                                        "resource": "aws_instance.fail_no_tags",
                                        "rule_name": "new_tagging_standard"
                                }
                        }
                ],
                "successes": []
        }
]
```