### PR TITLE
Use rego metadoc for rule metadata

### DIFF
--- a/lib/fugue_regula.rego
+++ b/lib/fugue_regula.rego
@@ -82,8 +82,22 @@ judgements_from_policies(policies) = ret {
 rule_report(pkg, judgements) = ret {
   ret = {
     "resources": {j.id: j | judgements[j]},
-    "valid": all([j.valid | judgements[j]])
+    "valid": all([j.valid | judgements[j]]),
+    "metadata": rule_metadata(pkg)
   }
+}
+
+rule_metadata(pkg) = ret {
+  ret = data["rules"][pkg]["__rego__metadoc__"]
+} else = ret {
+  ret = {}
+}
+
+controls(pkg) = ret {
+  metadata = rule_metadata(pkg)
+  ret = { c | c = metadata["custom"]["controls"][_][_] }
+} else = ret {
+  ret = set()
 }
 
 
@@ -152,7 +166,7 @@ report = ret {
     rule = {
       "package": pkg,
       "resource_type": resource_type,
-      "controls": {c | data.rules[pkg].controls[c]}
+      "controls": controls(pkg)
     }
   ]
 

--- a/rules/aws/cloudfront_distribution_https.rego
+++ b/rules/aws/cloudfront_distribution_https.rego
@@ -14,12 +14,22 @@
 # limitations under the License.
 package rules.cloudfront_distribution_https
 
-resource_type = "aws_cloudfront_distribution"
-
-controls = {
-  "NIST-800-53_AC-17 (2)",
-  "NIST-800-53_SC-8",
+__rego__metadoc__ := {
+  "id": "FG_R00011",
+  "title": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https",
+  "description": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https. CloudFront connections should be encrypted during transmission over networks that can be accessed by malicious individuals. A CloudFront distribution should only use HTTPS or Redirect HTTP to HTTPS for communication between viewers and CloudFront.",
+  "custom": {
+    "controls": {
+      "NIST": [
+        "NIST-800-53_AC-17 (2)",
+        "NIST-800-53_SC-8"
+      ]
+    },
+    "severity": "Medium"
+  }
 }
+
+resource_type = "aws_cloudfront_distribution"
 
 # Explicitly allow only https or redirection to https.
 valid_protocols = {

--- a/rules/aws/cloudtrail_log_file_validation.rego
+++ b/rules/aws/cloudtrail_log_file_validation.rego
@@ -13,13 +13,25 @@
 # limitations under the License.
 package rules.cloudtrail_log_file_validation
 
-resource_type = "aws_cloudtrail"
-controls = {
-  "CIS_2-2",
-  "NIST-800-53_AC-2g",
-  "NIST-800-53_AC-6 (9)",
-  "REGULA_R00006",
+__rego__metadoc__ := {
+  "id": "FG_R00027",
+  "title": "CloudTrail log file validation should be enabled",
+  "description": "CloudTrail log file validation should be enabled. It is recommended that file validation be enabled on all CloudTrail logs because it provides additional integrity checking of the log data.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_2-2"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-2g",
+        "NIST-800-53_AC-6 (9)"
+      ]
+    },
+    "severity": "Medium"
+  }
 }
+
+resource_type = "aws_cloudtrail"
 
 default allow = false
 

--- a/rules/aws/ebs_volume_encrypted.rego
+++ b/rules/aws/ebs_volume_encrypted.rego
@@ -13,8 +13,21 @@
 # limitations under the License.
 package rules.ebs_volume_encrypted
 
+__rego__metadoc__ := {
+  "id": "FG_R00016",
+  "title": "EBS volume encryption should be enabled",
+  "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
+  "custom": {
+    "controls": {
+      "NIST": [
+        "NIST-800-53_SC-13"
+      ]
+    },
+    "severity": "High"
+  }
+}
+
 resource_type = "aws_ebs_volume"
-controls = {"NIST-800-53_SC-13"}
 
 default allow = false
 

--- a/rules/aws/iam_admin_policy.rego
+++ b/rules/aws/iam_admin_policy.rego
@@ -15,11 +15,21 @@ package rules.iam_admin_policy
 
 import data.fugue
 
+__rego__metadoc__ := {
+  "id": "FG_R00092",
+  "title": "IAM policies should not have full \"*:*\" administrative privileges",
+  "description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_1-22"
+      ]
+    },
+    "severity": "High"
+  }
+}
+
 resource_type = "MULTIPLE"
-
-controls = {"CIS_1-22", "REGULA_R00002"}
-
-# IAM policies should not have full "*:*" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.
 
 # All policy objects that have a name and a `policy` field containing a JSON
 # string.

--- a/rules/aws/iam_user_attached_policy.rego
+++ b/rules/aws/iam_user_attached_policy.rego
@@ -15,14 +15,24 @@ package rules.iam_user_attached_policy
 
 import data.fugue
 
-resource_type = "MULTIPLE"
-controls = {
-  "CIS_1-16",
-  "NIST-800-53_AC-2 (7)(b)",
-  "REGULA_R00001",
+__rego__metadoc__ := {
+  "id": "FG_R00007",
+  "title": "IAM policies should not be attached directly to users",
+  "description": "IAM policies should not be attached to users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may reduce opportunity for a principal to inadvertently receive or retain excessive privileges.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_1-16"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-2 (7)(b)"
+      ]
+    },
+    "severity": "Low"
+  }
 }
 
-# IAM policies should not be attached to users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may reduce opportunity for a principal to inadvertently receive or retain excessive privileges.
+resource_type = "MULTIPLE"
 
 user_policies = fugue.resources("aws_iam_user_policy")
 user_policy_attachments = fugue.resources("aws_iam_user_policy_attachment")

--- a/rules/aws/kms_rotate.rego
+++ b/rules/aws/kms_rotate.rego
@@ -13,8 +13,21 @@
 # limitations under the License.
 package rules.kms_rotate
 
+__rego__metadoc__ := {
+  "id": "FG_R00036",
+  "title": "KMS CMK rotation should be enabled",
+  "description": "KMS CMK rotation should be enabled. It is recommended that users enable rotation for the customer created AWS Customer Master Key (CMK). Rotating encryption keys helps reduce the potential impact of a compromised key as users cannot use the old key to access the data.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_2-8"
+      ]
+    },
+    "severity": "Medium"
+  }
+}
+
 resource_type = "aws_kms_key"
-controls = {"CIS_2-8", "REGULA_R00007"}
 
 deny[msg] {
   not input.enable_key_rotation

--- a/rules/aws/s3_bucket_sse.rego
+++ b/rules/aws/s3_bucket_sse.rego
@@ -14,8 +14,21 @@
 # limitations under the License.
 package rules.s3_bucket_sse
 
+__rego__metadoc__ := {
+  "id": "FG_R00099",
+  "title": "S3 bucket server side encryption should be enabled",
+  "description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
+  "custom": {
+    "controls": {
+      "NIST": [
+        "NIST-800-53_SC-13"
+      ]
+    },
+    "severity": "High"
+  }
+}
+
 resource_type = "aws_s3_bucket"
-controls = {"NIST-800-53_SC-13"}
 
 # Explicitly allow AES256 or aws:kms server side SSE algorithms.
 valid_sse_algorithms = {

--- a/rules/aws/security_group_ingress_anywhere.rego
+++ b/rules/aws/security_group_ingress_anywhere.rego
@@ -15,6 +15,12 @@ package rules.security_group_ingress_anywhere
 
 import data.fugue.regula.aws.security_group as sglib
 
+__rego__metadoc__ := {
+  "id": "FG_R00351",
+  "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' except to ports 80 and 443",
+  "description": "VPC firewall rules should not permit unrestricted access from the internet, with the exception of port 80 (HTTP) and port 443 (HTTPS). Web applications or APIs generally need to be publicly accessible."
+}
+
 resource_type = "aws_security_group"
 
 whitelisted_ports = {80, 443}

--- a/rules/aws/security_group_ingress_anywhere_rdp.rego
+++ b/rules/aws/security_group_ingress_anywhere_rdp.rego
@@ -11,22 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# VPC security groups should not permit unrestricted access from the internet
-# to port 3389 (RDP). Removing unfettered connectivity to remote console
-# services, such as Remote Desktop Protocol, reduces a server's exposure to
-# risk.
 package rules.security_group_ingress_anywhere_rdp
 
 import data.fugue.regula.aws.security_group as sglib
 
-resource_type = "aws_security_group"
-controls = {
-  "CIS_4-2",
-  "NIST-800-53_AC-4",
-  "NIST-800-53_AC-17 (3)",
-  "REGULA_R00005",
+__rego__metadoc__ := {
+  "id": "FG_R00087",
+  "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
+  "description": "VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3389 (Remote Desktop Protocol). VPC security groups should not permit unrestricted access from the internet to port 3389 (RDP). Removing unfettered connectivity to remote console services, such as Remote Desktop Protocol, reduces a server's exposure to risk.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_4-2"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_AC-17 (3)"
+      ]
+    }
+  }
 }
+
+resource_type = "aws_security_group"
 
 default deny = false
 

--- a/rules/aws/security_group_ingress_anywhere_ssh.rego
+++ b/rules/aws/security_group_ingress_anywhere_ssh.rego
@@ -11,21 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# VPC security groups should not permit unrestricted access from the internet
-# to port 22 (SSH). Removing unfettered connectivity to remote console services,
-# such as SSH, reduces a server's exposure to risk.
 package rules.security_group_ingress_anywhere_ssh
 
 import data.fugue.regula.aws.security_group as sglib
 
-resource_type = "aws_security_group"
-controls = {
-  "CIS_4-1",
-  "NIST-800-53_AC-4",
-  "NIST-800-53_AC-17 (3)",
-  "REGULA_R00004",
+__rego__metadoc__ := {
+  "id": "FG_R00085",
+  "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
+  "description": "VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH). VPC security groups should not permit unrestricted access from the internet to port 22 (SSH). Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_4-1"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_AC-17 (3)"
+      ]
+    }
+  }
 }
+
+resource_type = "aws_security_group"
 
 default deny = false
 

--- a/rules/aws/vpc_flow_log.rego
+++ b/rules/aws/vpc_flow_log.rego
@@ -15,16 +15,26 @@ package rules.vpc_flow_log
 
 import data.fugue
 
-resource_type = "MULTIPLE"
-controls = {
-  "CIS_2-9",
-  "NIST-800-53_AC-4",
-  "NIST-800-53_SC-7a",
-  "NIST-800-53_SI-4a.2",
-  "REGULA_R00003",
+__rego__metadoc__ := {
+  "id": "FG_R00054",
+  "title": "VPC flow logging should be enabled",
+  "description": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC. Users can use the flow logs to detect anomalous traffic or insight during security workflows.",
+  "custom": {
+    "controls": {
+      "CIS": [
+        "CIS_2-9"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_SC-7a",
+        "NIST-800-53_SI-4a.2"
+      ]
+    },
+    "severity": "Medium"
+  }
 }
 
-# VPC flow logging should be enabled when VPCs are created. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC. Users can use the flow logs to detect anomalous traffic or insight during security workflows.
+resource_type = "MULTIPLE"
 
 # every flow log in the template
 flow_logs = fugue.resources("aws_flow_log")

--- a/rules/azure/network_security_group_no_inbound_22.rego
+++ b/rules/azure/network_security_group_no_inbound_22.rego
@@ -11,22 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH).
-# Removing unfettered connectivity to remote console services, such as SSH,
-# reduces a server's exposure to risk.
 package rules.network_security_group_no_inbound_22
 
 import data.fugue.azure.network_security_group
 
-resource_type = "azurerm_network_security_group"
-controls = {
-  "CIS_Azure_1.1.0_6-1",
-  "NIST‌-800-53_AC‌-4",
-  "NIST‌-800-53_SC‌-7a",
-  "NIST‌-800-53_SI‌-4a.2",
-  "REGULA_R00019",
+__rego__metadoc__ := {
+  "id": "FG_R00190",
+  "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
+  "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH). The potential security problem with using SSH over the internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on the Azure Virtual Network or even attack networked devices outside of Azure.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_6.1"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_SC-7a",
+        "NIST-800-53_SI-4a.2"
+      ]
+    },
+    "severity": "High"
+  }
 }
+
+resource_type = "azurerm_network_security_group"
 
 default deny = false
 

--- a/rules/azure/network_security_group_no_inbound_3389.rego
+++ b/rules/azure/network_security_group_no_inbound_3389.rego
@@ -11,16 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (RDP).
-# Removing unfettered connectivity to remote console services, such as RDP,
-# reduces a server's exposure to risk.
 package rules.network_security_group_no_inbound_3389
 
 import data.fugue.azure.network_security_group
 
+__rego__metadoc__ := {
+  "id": "FG_R00191",
+  "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
+  "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3389 (RDP). The potential security problem with using RDP over the Internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on an Azure Virtual Network or even attack networked devices outside of Azure.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_6.2"
+      ]
+    },
+    "severity": "High"
+  }
+}
+
 resource_type = "azurerm_network_security_group"
-controls = {"CIS_Azure_1.1.0_6-2", "REGULA_R00020"}
 
 default deny = false
 

--- a/rules/azure/network_security_rule_no_inbound_22.rego
+++ b/rules/azure/network_security_rule_no_inbound_22.rego
@@ -11,22 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH).
-# Removing unfettered connectivity to remote console services, such as SSH,
-# reduces a server's exposure to risk.
 package rules.network_security_rule_no_inbound_22
 
 import data.fugue.azure.network_security_group
 
-resource_type = "azurerm_network_security_rule"
-controls = {
-  "CIS_Azure_1.1.0_6-1",
-  "NIST‌-800-53_AC‌-4",
-  "NIST‌-800-53_SC‌-7a",
-  "NIST‌-800-53_SI‌-4a.2",
-  "REGULA_R00019",
+__rego__metadoc__ := {
+  "id": "FG_R00190",
+  "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
+  "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH). The potential security problem with using SSH over the internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on the Azure Virtual Network or even attack networked devices outside of Azure.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_6.1"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_SC-7a",
+        "NIST-800-53_SI-4a.2"
+      ]
+    }
+  }
 }
+
+resource_type = "azurerm_network_security_rule"
 
 default deny = false
 

--- a/rules/azure/network_security_rule_no_inbound_3389.rego
+++ b/rules/azure/network_security_rule_no_inbound_3389.rego
@@ -11,22 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (RDP).
-# Removing unfettered connectivity to remote console services, such as RDP,
-# reduces a server's exposure to risk.
 package rules.network_security_rule_no_inbound_3389
 
 import data.fugue.azure.network_security_group
 
-resource_type = "azurerm_network_security_rule"
-controls = {
-  "CIS_Azure_1.1.0_6-2",
-  "NIST‌-800-53_AC‌-4",
-  "NIST‌-800-53_SC‌-7a",
-  "NIST‌-800-53_SI‌-4a.2",
-  "REGULA_R00020",
+__rego__metadoc__ := {
+  "id": "FG_R00191",
+  "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
+  "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3389 (RDP). The potential security problem with using RDP over the Internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on an Azure Virtual Network or even attack networked devices outside of Azure.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_6.2"
+      ],
+      "NIST": [
+        "NIST-800-53_AC-4",
+        "NIST-800-53_SC-7a",
+        "NIST-800-53_SI-4a.2"
+      ]
+    }
+  }
 }
+
+resource_type = "azurerm_network_security_rule"
 
 default deny = false
 

--- a/rules/azure/sql_server_firewall_no_inbound_all.rego
+++ b/rules/azure/sql_server_firewall_no_inbound_all.rego
@@ -11,20 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# SQL Server firewall rules should not permit ingress from 0.0.0.0/0 to
-# all ports and protocols. To reduce the potential attack surface for a
-# SQL server, firewall rules should be defined with more granular IP addresses
-# by referencing the range of addresses available from specific data centers.
-
 package rules.sql_server_firewall_no_inbound_all
 
-resource_type = "azurerm_sql_firewall_rule"
-controls = {
-  "CIS_Azure_1.1.0_6-3",
-  "NIST-800-53_SC-7 (5)",
-  "REGULA_R00021",
+__rego__metadoc__ := {
+  "id": "FG_R00192",
+  "title": "SQL Server firewall rules should not permit ingress from 0.0.0.0/0 to all ports and protocols",
+  "description": "Virtual Network security groups attached to SQL Server instances should not permit ingress from 0.0.0.0/0 to all ports and protocols. To reduce the potential attack surface for a SQL server, firewall rules should be defined with more granular IP addresses by referencing the range of addresses available from specific data centers.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_6.3"
+      ],
+      "NIST": [
+        "NIST-800-53_SC-7 (5)"
+      ]
+    },
+    "severity": "High"
+  }
 }
+
+resource_type = "azurerm_sql_firewall_rule"
 
 default deny = false
 

--- a/rules/azure/storage_account_deny_access.rego
+++ b/rules/azure/storage_account_deny_access.rego
@@ -11,13 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Storage accounts should deny access from all networks.
-# Restricting default network access helps to provide a new layer of security,
-# since storage accounts accept connections from clients on any network.
 package rules.storage_account_deny_access
 
-controls = {"CIS_Azure_1.1.0_3-7", "REGULA_R00017"}
+__rego__metadoc__ := {
+  "id": "FG_R00154",
+  "title": "Storage accounts should deny access from all networks by default",
+  "description": "Storage accounts should be configured to deny access to traffic from all networks. Access can be granted to traffic from specific Azure Virtual networks, allowing a secure network boundary for specific applications to be built. Access can also be granted to public internet IP address ranges, to enable connections from specific internet or on-premises clients. When network rules are configured, only applications from allowed networks can access a storage account. When calling from an allowed network, applications continue to require proper authorization (a valid access key or SAS token) to access the storage account.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_3.7"
+      ]
+    }
+  }
+}
+
 resource_type = "azurerm_storage_account"
 
 default allow = false

--- a/rules/azure/storage_account_microsoft_services.rego
+++ b/rules/azure/storage_account_microsoft_services.rego
@@ -11,15 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Storage accounts 'Trusted Microsoft Services' access should be enabled.
-# Some Microsoft services that interact with storage accounts operate
-# from networks that can't be granted access through network rules.
-# To help this type of service work as intended, allow the set of trusted
-# Microsoft services to bypass the network rules.
 package rules.storage_account_microsoft_services
 
-controls = {"CIS_Azure_1.1.0_3-8", "REGULA_R00018"}
+__rego__metadoc__ := {
+  "id": "FG_R00208",
+  "title": "Storage accounts 'Trusted Microsoft Services' access should be enabled",
+  "description": " Enabling \"Trusted Microsoft Services\" allows Azure services (Azure Backup, Azure Site Recovery, Azure DevTest Labs, Azure Event Grid, Azure Event Hubs, Azure Networking, Azure Monitor and Azure SQL Data Warehouse) to access your storage account and bypass any firewall rules.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_3.8"
+      ]
+    }
+  }
+}
+
 resource_type = "azurerm_storage_account"
 
 default allow = false

--- a/rules/azure/storage_account_secure_transfer.rego
+++ b/rules/azure/storage_account_secure_transfer.rego
@@ -11,15 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Storage Accounts 'Secure transfer required' should be enabled.
-# The secure transfer option enhances the security of a storage account
-# by only allowing requests to the storage account by a secure connection.
-# This control does not apply for custom domain names since Azure storage does not support HTTPS for custom domain names.
-
 package rules.storage_account_secure_transfer
 
-controls = {"CIS_Azure_1.1.0_3-1", "REGULA_R00015"}
+__rego__metadoc__ := {
+  "id": "FG_R00152",
+  "title": "Storage Accounts 'Secure transfer required' should be enabled",
+  "description": "Storage Accounts 'Secure transfer required' should be enabled. The secure transfer option enhances the security of a storage account by only allowing requests to the storage account by a secure connection. This control does not apply for custom domain names since Azure storage does not support HTTPS for custom domain names.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_3.1"
+      ]
+    },
+    "severity": "Medium"
+  }
+}
+
 resource_type = "azurerm_storage_account"
 
 default allow = false

--- a/rules/azure/storage_container_private_access.rego
+++ b/rules/azure/storage_container_private_access.rego
@@ -11,13 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Storage containers should have access set to 'private'.
-# Anonymous, public read access to a container and its blobs can be
-# enabled in Azure Blob storage. This is only recommended if absolutely necessary.
 package rules.storage_container_private_access
 
-controls = {"CIS_Azure_1.1.0_3-6", "REGULA_R00016"}
+__rego__metadoc__ := {
+  "id": "FG_R00207",
+  "title": "Blob Storage containers should have public access disabled",
+  "description": "Anonymous, public read access to a container and its blobs can be enabled in Azure Blob storage. It grants read-only access to these resources without sharing the account key, and without requiring a shared access signature. It is recommended not to provide anonymous access to blob containers until, and unless, it is strongly desired. A shared access signature token should be used for providing controlled and timed access to blob containers.",
+  "custom": {
+    "controls": {
+      "CISAZURE": [
+        "CISAZURE_3.6"
+      ]
+    }
+  }
+}
+
 resource_type = "azurerm_storage_container"
 
 default allow = false

--- a/rules/gcp/compute_firewall_no_ingress_22.rego
+++ b/rules/gcp/compute_firewall_no_ingress_22.rego
@@ -19,7 +19,19 @@ package rules.gcp_compute_firewall_no_ingress_22
 
 import data.fugue.gcp.compute_firewall
 
-controls = {"CIS_GCP_3-6", "REGULA_R00011"}
+__rego__metadoc__ := {
+  "id": "FG_R00353",
+  "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
+  "description": "VPC firewall rules should not permit unrestricted access from the internet to port 22 (SSH). Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.",
+  "custom": {
+    "controls": {
+      "CIS-GCP": [
+        "CIS-GCP_1.0.0_3-6"
+      ]
+    }
+  }
+}
+
 resource_type = "google_compute_firewall"
 
 default deny = false

--- a/rules/gcp/compute_firewall_no_ingress_3389.rego
+++ b/rules/gcp/compute_firewall_no_ingress_3389.rego
@@ -19,7 +19,19 @@ package rules.gcp_compute_firewall_no_ingress_3389
 
 import data.fugue.gcp.compute_firewall
 
-controls = {"CIS_GCP_3-7", "REGULA_R00012"}
+__rego__metadoc__ := {
+  "id": "FG_R00354",
+  "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
+  "description": "VPC firewall rules should not permit unrestricted access from the internet to port 3389 (RDP). Removing unfettered connectivity to remote console services, such as Remote Desktop Protocol, reduces a server's exposure to risk.",
+  "custom": {
+    "controls": {
+      "CIS-GCP": [
+        "CIS-GCP_1.0.0_3-7"
+      ]
+    }
+  }
+}
+
 resource_type = "google_compute_firewall"
 
 default deny = false

--- a/rules/gcp/compute_subnet_flow_log_enabled.rego
+++ b/rules/gcp/compute_subnet_flow_log_enabled.rego
@@ -15,7 +15,19 @@
 # VPC subnet flow logging should be enabled.
 package rules.gcp_compute_subnet_flow_log_enabled
 
-controls = {"CIS_GCP_3-9", "REGULA_R00014"}
+__rego__metadoc__ := {
+  "id": "FG_R00356",
+  "title": "VPC subnet flow logging should be enabled",
+  "description": "Flow logs provide visibility into network traffic that traverses a VPC, and can be used to detect anomalous traffic and additional insights.",
+  "custom": {
+    "controls": {
+      "CIS-GCP": [
+        "CIS-GCP_1.0.0_3-9"
+      ]
+    }
+  }
+}
+
 resource_type = "google_compute_subnetwork"
 
 default deny = false

--- a/rules/gcp/compute_subnet_private_google_access.rego
+++ b/rules/gcp/compute_subnet_private_google_access.rego
@@ -17,7 +17,19 @@
 # access Google APIs and services by using Private Google Access.
 package rules.gcp_compute_subnet_private_google_access
 
-controls = {"CIS_GCP_3-8", "REGULA_R00013"}
+__rego__metadoc__ := {
+  "id": "REGULA_R00013",
+  "title": "VPC subnet 'Private Google Access' should be enabled",
+  "description": "Enabling \"Private Google Access\" for VPC subnets allows virtual machines to connect to the external IP addresses used by Google APIs and services.",
+  "custom": {
+    "controls": {
+      "CIS-GCP": [
+        "CIS-GCP_1.0.0_3-8"
+      ]
+    }
+  }
+}
+
 resource_type = "google_compute_subnetwork"
 
 default allow = false

--- a/rules/gcp/kms_cryptokey_rotate.rego
+++ b/rules/gcp/kms_cryptokey_rotate.rego
@@ -15,7 +15,19 @@
 # KMS crypto keys should be rotated at least once every 365 days
 package rules.gcp_kms_cryptokey_rotate
 
-controls = {"CIS_GCP_1-8", "REGULA_R00010"}
+__rego__metadoc__ := {
+  "id": "FG_R00352",
+  "title": "KMS crypto keys should be rotated at least once every 365 days",
+  "description": "Key rotation is a security best practice that helps reduce the potential impact of a compromised key, as users cannot use deprecated/older keys.",
+  "custom": {
+    "controls": {
+      "CIS-GCP": [
+        "CIS-GCP_1.0.0_1-8"
+      ]
+    }
+  }
+}
+
 resource_type = "google_kms_crypto_key"
 
 default allow = false

--- a/tests/lib/fugue_regula_report_test.rego
+++ b/tests/lib/fugue_regula_report_test.rego
@@ -25,7 +25,13 @@ mock_plan_input = ebs_volume_encrypted_infra.mock_plan_input
 # We construct some mock rules as well.
 mock_rules = {
   "always_pass": {
-    "controls": {"MOCK_1.2.3"},
+    "__rego__metadoc__": {
+      "custom": {
+        "controls": {
+          "MOCK": ["MOCK_1.2.3"]
+        }
+      }
+    },
     "resource_type": "aws_ebs_volume",
     "allow": true
   },


### PR DESCRIPTION
# Description

This PR implements the proposed [regodoc standard](https://hackmd.io/@ZtQnh19kS26YiNlJLqKJnw/H1gAv5nBw) for rule metadata. I've also added and changed some information for each rule.

## Why?

Adopting this standard allows us to embed rule metadata in a format that is easy to process with other tools.

## Additional information for each rule

* ID
    * The IDs are sourced from Fugue's rule database
* Title
* Description
* Severity
* Compliance family
    * This was previously implied by the prefix of the control tag, but is now used as a way to group controls

## Changed information

* Removed the `REGULA_...` entries in controls
* Standardized control tags to Fugue's rule database
    * Control tags refer to the control names / IDs, e.g. `CIS_1-1`

# Changes to the report output

Apart from the changed information mentioned above, each `rules` entry in the report output will contain a `metadata` entry:

```json
    "rules": {
      "s3_bucket_sse": {
        "resources": {
          "...": "..."
        },
        "metadata": {
          "custom": {
            "controls": {
              "NIST": [
                "NIST-800-53_SC-13"
              ]
            },
            "severity": "High"
          },
          "id": "FG_R00099",
          "title": "S3 bucket server side encryption should be enabled",
          "description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C)."
        },
        "valid": false
      }
    }
```

`metadata` will be the contents of `__rego__metadoc__` added to each rule.

# Important information for users

Users who have written their own rules for Regula that contain a `controls` rule will need to move that information into a `__rego__metadoc__` rule:

### Before

```
controls = {"CIS_1-1"}
```

### After

```
__rego__metadoc__ := {
  "custom": {
    "controls": {
      "CIS": ["CIS_1-1"]
    }
  }
}
```

Users who are parsing the report output of specific control tags may need to update their integration to use the new control tags.

# Remaining work

These two pairs of rules currently have duplicated IDs

* `rules/azure/network_security_group_no_inbound_22.rego` and `rules/azure/network_security_rule_no_inbound_22.rego`
* `rules/azure/network_security_group_no_inbound_3389.rego` and `rules/azure/network_security_rule_no_inbound_3389.rego`

These rules will be combined in a subsequent PR.