### PR TITLE
add option to use existing json

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Some examples:
 It is also possible to set the name of the `terraform` executable, which is
 useful if you have several versions installed:
 
-    env TERRAFORM=terraform-v0.12.18 ./bin/regula --terraform-dir regula-ci-example/ --rego-paths lib
+    env TERRAFORM=terraform-v0.12.18 ./bin/regula --terraform-dir ../regula-ci-example/ --rego-paths lib
 
 Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatted plan.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Regula includes a library of rules written in Rego, the policy language used by 
 ## How does Regula work?
 
 There are two parts to Regula. The first is a [shell script](/bin/regula)
-that generates a [terraform] plan in JSON format, ready for consumption by
+that generates a [terraform] plan or use existing in JSON format, ready for consumption by 
 [opa].
 
 The second part is a Rego framework that:
@@ -90,7 +90,7 @@ Install the prerequisites:
 
 Run the following command:
 
-    ./bin/regula [TERRAFORM_PATH] [REGO_PATHS...]
+    ./bin/regula --terraform-dir [TERRAFORM_PATH] --rego-paths REGO_PATH1 --rego-paths REGO_PATH2
 
 `TERRAFORM_PATH` is the directory where your Terraform configuration files are
 located.
@@ -100,17 +100,19 @@ should at least include `lib/`.
 
 Some examples:
 
--   `./bin/regula ../my-tf-infra .`: conveniently check `../my-tf-infra` against
+-   `./bin/regula --terraform-dir ../my-tf-infra  --rego-paths .`: conveniently check `../my-tf-infra` against
     all rules in this main repository.
--   `./bin/regula ../my-tf-infra lib examples/aws/ec2_t2_only.rego`: run Regula
+-   `./bin/regula --terraform-json ../my-tf-infra.json  --rego-paths .`: conveniently check `../my-tf-infra.json` terraform plan file in json against
+    all rules in this main repository.
+-   `./bin/regula --terraform-dir  ../my-tf-infra --rego-paths lib --rego-paths examples/aws/ec2_t2_only.rego`: run Regula
     using only the specified rule.
--   `./bin/regula ../my-tf-infra lib ../custom-rules`: run Regula using a
+-   `./bin/regula  --terraform-dir ../my-tf-infra  --rego-paths lib --rego-paths ../custom-rules`: run Regula using a
     directory of custom rules.
 
 It is also possible to set the name of the `terraform` executable, which is
 useful if you have several versions installed:
 
-    env TERRAFORM=terraform-v0.12.18 ./bin/regula ../regula-ci-example/ lib
+    env TERRAFORM=terraform-v0.12.18 ./bin/regula --terraform-dir regula-ci-example/ --rego-paths lib
 
 Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatted plan.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Regula includes a library of rules written in Rego, the policy language used by 
 ## How does Regula work?
 
 There are two parts to Regula. The first is a [shell script](/bin/regula)
-that generates a [terraform] plan or use existing in JSON format, ready for consumption by 
-[opa].
+that generates a [terraform] plan or use existing in JSON format, ready for consumption by [opa].
 
 The second part is a Rego framework that:
 
@@ -90,7 +89,7 @@ Install the prerequisites:
 
 Run the following command:
 
-    ./bin/regula --terraform-dir [TERRAFORM_PATH] --rego-paths REGO_PATH1 --rego-paths REGO_PATH2
+    ./bin/regula [TERRAFORM_PATH] [REGO_PATHS...]
 
 `TERRAFORM_PATH` is the directory where your Terraform configuration files are
 located.
@@ -100,19 +99,19 @@ should at least include `lib/`.
 
 Some examples:
 
--   `./bin/regula --terraform-dir ../my-tf-infra  --rego-paths .`: conveniently check `../my-tf-infra` against
+-   `./bin/regula ../my-tf-infra .`: conveniently check `../my-tf-infra` against
     all rules in this main repository.
--   `./bin/regula --terraform-json ../my-tf-infra.json  --rego-paths .`: conveniently check `../my-tf-infra.json` terraform plan file in json against
+-   `./bin/regula ../my-tf-infra.json .`: conveniently check `../my-tf-infra.json` terraform plan against
     all rules in this main repository.
--   `./bin/regula --terraform-dir  ../my-tf-infra --rego-paths lib --rego-paths examples/aws/ec2_t2_only.rego`: run Regula
+-   `./bin/regula ../my-tf-infra lib examples/aws/ec2_t2_only.rego`: run Regula
     using only the specified rule.
--   `./bin/regula  --terraform-dir ../my-tf-infra  --rego-paths lib --rego-paths ../custom-rules`: run Regula using a
+-   `./bin/regula ../my-tf-infra lib ../custom-rules`: run Regula using a
     directory of custom rules.
 
 It is also possible to set the name of the `terraform` executable, which is
 useful if you have several versions installed:
 
-    env TERRAFORM=terraform-v0.12.18 ./bin/regula --terraform-dir ../regula-ci-example/ --rego-paths lib
+    env TERRAFORM=terraform-v0.12.18 ./bin/regula ../regula-ci-example/ lib
 
 Note that Regula requires Terraform 0.12+ in order to generate the JSON-formatted plan.
 

--- a/bin/regula
+++ b/bin/regula
@@ -15,61 +15,27 @@
 set -o nounset -o errexit -o pipefail
 
 # Basic command line argument handling.
-function print_usage {
-  echo
-  echo "Usage: regula [options]"
-  echo
-  echo
-  echo "Options:"
-  echo
-  echo -e "  --terraform-dir\t terraform directory to run terraform plan"
-  echo -e "  --terraform-json\t Use terraform plan in json format instead of calling terraform plan to generate json file"
-  echo -e "  --rego-paths\t\t he directories that need to be searched for Rego code. This should at least include lib/. Can be called multiple times"
-  echo -e "  --help\t\t Show this help text and exit."
-  echo
-  echo "Example:"
-  echo
-  echo "  regula --terraform-dir ../my-tf-infra "
-   echo "  regula --terraform-json ../my-tf-infra.json --rego-paths lib  --rego-paths  examples/aws/ec2_t2_only.rego "
-}
-REGO_PATHS=()
+if [[ $# -lt 1 ]]; then
+  1>&2 echo "Usage: $0 [TERRAFORM_DIR or TERRAFORM_PLAN_JSON] [REGO_PATHS..]"
+  1>&2 echo ""
+  1>&2 echo "Regula is a little wrapper to run Rego validations on terraform"
+  1>&2 echo "files.  It is meant to be used as a pre-flight check before"
+  1>&2 echo "deployment."
+  exit 1
+fi
+echo $1
 
-while [[ $# -gt 0 ]]; do
-    key="$1"
-
-    case "$key" in
-      --terraform-dir)
-        TERRAFORM_DIR="$2"
-        shift
-        ;;
-     
-      --terraform-json)
-        TERRAFORM_PLAN_JSON="$2"
-        shift
-        ;;
-      --rego-paths)
-        REGO_PATHS+=("$2")
-        echo "$2"
-        shift
-        ;;
-      --help)
-        print_usage
-        exit
-        ;;
-      *)
-        echo "ERROR: Unrecognized option: $key"
-        print_usage
-        exit 1
-        ;;
-    esac
-
-    shift
-  done
-
-if [[ ! -v TERRAFORM_DIR ]] && [[ ! -v TERRAFORM_PLAN_JSON ]] ; then
-    echo "You must specify --terraform-dir or --terraform-json. Both cannot be empty at the same time"
+if [[ -d "$1" ]]; then
+    TERRAFORM_DIR="$1"
+elif [[ -f "$1" ]]; then
+    TERRAFORM_PLAN_JSON="$1"
+else
+    echo "Error: $1 should be a file or directory"
     exit 1
 fi
+shift 1
+REGO_PATHS=("$@")
+
 # Setting this variable will cause terraform to print a little less information
 # on what to do next.
 TF_IN_AUTOMATION=true

--- a/bin/regula
+++ b/bin/regula
@@ -15,19 +15,61 @@
 set -o nounset -o errexit -o pipefail
 
 # Basic command line argument handling.
-if [[ $# -lt 1 ]]; then
-  1>&2 echo "Usage: $0 TERRAFORM_DIR [REGO_PATHS..]"
-  1>&2 echo ""
-  1>&2 echo "Regula is a little wrapper to run Rego validations on terraform"
-  1>&2 echo "files.  It is meant to be used as a pre-flight check before"
-  1>&2 echo "deployment."
-  exit 1
+function print_usage {
+  echo
+  echo "Usage: regula [options]"
+  echo
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --terraform-dir\t terraform directory to run terraform plan"
+  echo -e "  --terraform-json\t Use terraform plan in json format instead of calling terraform plan to generate json file"
+  echo -e "  --rego-paths\t\t he directories that need to be searched for Rego code. This should at least include lib/. Can be called multiple times"
+  echo -e "  --help\t\t Show this help text and exit."
+  echo
+  echo "Example:"
+  echo
+  echo "  regula --terraform-dir ../my-tf-infra "
+   echo "  regula --terraform-json ../my-tf-infra.json --rego-paths lib  --rego-paths  examples/aws/ec2_t2_only.rego "
+}
+REGO_PATHS=()
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case "$key" in
+      --terraform-dir)
+        TERRAFORM_DIR="$2"
+        shift
+        ;;
+     
+      --terraform-json)
+        TERRAFORM_PLAN_JSON="$2"
+        shift
+        ;;
+      --rego-paths)
+        REGO_PATHS+=("$2")
+        echo "$2"
+        shift
+        ;;
+      --help)
+        print_usage
+        exit
+        ;;
+      *)
+        echo "ERROR: Unrecognized option: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+if [[ ! -v TERRAFORM_DIR ]] && [[ ! -v TERRAFORM_PLAN_JSON ]] ; then
+    echo "You must specify --terraform-dir or --terraform-json. Both cannot be empty at the same time"
+    exit 1
 fi
-
-TERRAFORM_DIR="$1"
-shift 1
-REGO_PATHS=("$@")
-
 # Setting this variable will cause terraform to print a little less information
 # on what to do next.
 TF_IN_AUTOMATION=true
@@ -49,19 +91,24 @@ function silently {
   rm "$log"
 }
 
-# Temporary files.
-TERRAFORM_PLAN="$(mktemp -t plan.XXXXXXX)"
-TERRAFORM_PLAN_JSON="$(mktemp -t plan.json.XXXXXXX)"
-function cleanup {
-    rm -f "$TERRAFORM_PLAN" "$TERRAFORM_PLAN_JSON"
-}
-trap cleanup exit
+if [[ ! -v TERRAFORM_PLAN_JSON ]] ; then #TERRAFORM_PLAN_JSON provided as a parameter
 
-# Run terraform to obtain the plan.
-(cd "$TERRAFORM_DIR" &&
-    silently "$TERRAFORM" init &&
-    silently "$TERRAFORM" plan -refresh=false -out="$TERRAFORM_PLAN" &&
-    "$TERRAFORM" show -json "$TERRAFORM_PLAN" >"$TERRAFORM_PLAN_JSON")
+  # Temporary files.
+  TERRAFORM_PLAN="$(mktemp -t plan.XXXXXXX)"
+  TERRAFORM_PLAN_JSON="$(mktemp -t plan.json.XXXXXXX)"
+  function cleanup {
+      rm -f "$TERRAFORM_PLAN" "$TERRAFORM_PLAN_JSON"
+  }
+  trap cleanup exit
+
+
+  # Run terraform to obtain the plan.
+  (cd "$TERRAFORM_DIR" &&
+      silently "$TERRAFORM" init &&
+      silently "$TERRAFORM" plan -refresh=false -out="$TERRAFORM_PLAN" &&
+      "$TERRAFORM" show -json "$TERRAFORM_PLAN" >"$TERRAFORM_PLAN_JSON")
+
+fi
 
 # Prepend `-d` to every argument because `opa` expects to see many `-d`
 # arguments.


### PR DESCRIPTION
add parameter --terraform-dir,  --terraform-json and --rego-paths to be able to consume existing json plan file instead of creating from scratch
