### PR TITLE
Assigned new rule IDs to rules; swapped two other IDs

### DIFF
--- a/rules/aws/security_group_ingress_anywhere.rego
+++ b/rules/aws/security_group_ingress_anywhere.rego
@@ -16,7 +16,7 @@ package rules.security_group_ingress_anywhere
 import data.fugue.regula.aws.security_group as sglib
 
 __rego__metadoc__ := {
-  "id": "FG_R00351",
+  "id": "FG_R00377",
   "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' except to ports 80 and 443",
   "description": "VPC firewall rules should not permit unrestricted access from the internet, with the exception of port 80 (HTTP) and port 443 (HTTPS). Web applications or APIs generally need to be publicly accessible."
 }

--- a/rules/azure/network_security_group_no_inbound_22.rego
+++ b/rules/azure/network_security_group_no_inbound_22.rego
@@ -17,7 +17,7 @@ import data.fugue
 import data.fugue.azure.network_security_group
 
 __rego__metadoc__ := {
-  "id": "FG_R00190",
+  "id": "FG_R00191",
   "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
   "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH). The potential security problem with using SSH over the internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on the Azure Virtual Network or even attack networked devices outside of Azure.",
   "custom": {

--- a/rules/azure/network_security_group_no_inbound_3389.rego
+++ b/rules/azure/network_security_group_no_inbound_3389.rego
@@ -17,7 +17,7 @@ import data.fugue
 import data.fugue.azure.network_security_group
 
 __rego__metadoc__ := {
-  "id": "FG_R00191",
+  "id": "FG_R00190",
   "title": "Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
   "description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3389 (RDP). The potential security problem with using RDP over the Internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on an Azure Virtual Network or even attack networked devices outside of Azure.",
   "custom": {

--- a/rules/gcp/compute_firewall_no_ingress_22.rego
+++ b/rules/gcp/compute_firewall_no_ingress_22.rego
@@ -20,7 +20,7 @@ package rules.gcp_compute_firewall_no_ingress_22
 import data.fugue.gcp.compute_firewall
 
 __rego__metadoc__ := {
-  "id": "FG_R00353",
+  "id": "FG_R00379",
   "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
   "description": "VPC firewall rules should not permit unrestricted access from the internet to port 22 (SSH). Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.",
   "custom": {

--- a/rules/gcp/compute_firewall_no_ingress_3389.rego
+++ b/rules/gcp/compute_firewall_no_ingress_3389.rego
@@ -20,7 +20,7 @@ package rules.gcp_compute_firewall_no_ingress_3389
 import data.fugue.gcp.compute_firewall
 
 __rego__metadoc__ := {
-  "id": "FG_R00354",
+  "id": "FG_R00380",
   "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
   "description": "VPC firewall rules should not permit unrestricted access from the internet to port 3389 (RDP). Removing unfettered connectivity to remote console services, such as Remote Desktop Protocol, reduces a server's exposure to risk.",
   "custom": {

--- a/rules/gcp/compute_subnet_flow_log_enabled.rego
+++ b/rules/gcp/compute_subnet_flow_log_enabled.rego
@@ -16,7 +16,7 @@
 package rules.gcp_compute_subnet_flow_log_enabled
 
 __rego__metadoc__ := {
-  "id": "FG_R00356",
+  "id": "FG_R00381",
   "title": "VPC subnet flow logging should be enabled",
   "description": "Flow logs provide visibility into network traffic that traverses a VPC, and can be used to detect anomalous traffic and additional insights.",
   "custom": {

--- a/rules/gcp/kms_cryptokey_rotate.rego
+++ b/rules/gcp/kms_cryptokey_rotate.rego
@@ -16,7 +16,7 @@
 package rules.gcp_kms_cryptokey_rotate
 
 __rego__metadoc__ := {
-  "id": "FG_R00352",
+  "id": "FG_R00378",
   "title": "KMS crypto keys should be rotated at least once every 365 days",
   "description": "Key rotation is a security best practice that helps reduce the potential impact of a compromised key, as users cannot use deprecated/older keys.",
   "custom": {


### PR DESCRIPTION
I assigned new rule IDs to a several rules because of conflicts with existing rules. I also fixed a mistake (that I made) where the IDs of these two rules were swapped:

rules/azure/network_security_group_no_inbound_3389.rego
rules/azure/network_security_group_no_inbound_22.rego