### PR TITLE
[RM-5219] Skip cloudtrail_s3_data_logging rules in templates without trails

### DIFF
--- a/rules/cfn/s3/cloudtrail_s3_data_logging_read.rego
+++ b/rules/cfn/s3/cloudtrail_s3_data_logging_read.rego
@@ -36,6 +36,10 @@ resource_type = "MULTIPLE"
 trails = fugue.resources("AWS::CloudTrail::Trail")
 buckets = fugue.resources("AWS::S3::Bucket")
 
+has_trails {
+  count(trails) > 0
+}
+
 valid_selector_types = {
   "All",
   "ReadOnly"
@@ -57,11 +61,16 @@ valid_buckets[bucket_id] {
   cloudtrail.event_selector_applies_to_bucket(event_selector, bucket)
 }
 
+# TODO: We're skipping these rules when a template does not contain both S3 buckets
+# and CloudTrail trails. Another possible approach is to add a new type of "unknown"
+# result for resources and use that when the template only contains S3 buckets.
 policy[j] {
+  has_trails
   bucket := buckets[bucket_id]
   valid_buckets[bucket_id]
   j := fugue.allow_resource(bucket)
 } {
+  has_trails
   bucket := buckets[bucket_id]
   not valid_buckets[bucket_id]
   j := fugue.deny_resource(bucket)

--- a/rules/cfn/s3/cloudtrail_s3_data_logging_write.rego
+++ b/rules/cfn/s3/cloudtrail_s3_data_logging_write.rego
@@ -36,6 +36,10 @@ resource_type = "MULTIPLE"
 trails = fugue.resources("AWS::CloudTrail::Trail")
 buckets = fugue.resources("AWS::S3::Bucket")
 
+has_trails {
+  count(trails) > 0
+}
+
 valid_selector_types = {
   "All",
   "WriteOnly"
@@ -57,11 +61,16 @@ valid_buckets[bucket_id] {
   cloudtrail.event_selector_applies_to_bucket(event_selector, bucket)
 }
 
+# TODO: We're skipping these rules when a template does not contain both S3 buckets
+# and CloudTrail trails. Another possible approach is to add a new type of "unknown"
+# result for resources and use that when the template only contains S3 buckets.
 policy[j] {
+  has_trails
   bucket := buckets[bucket_id]
   valid_buckets[bucket_id]
   j := fugue.allow_resource(bucket)
 } {
+  has_trails
   bucket = buckets[bucket_id]
   not valid_buckets[bucket_id]
   j := fugue.deny_resource(bucket)

--- a/tests/rules/cfn/s3/cloudtrail_s3_data_logging_read_test.rego
+++ b/tests/rules/cfn/s3/cloudtrail_s3_data_logging_read_test.rego
@@ -76,10 +76,8 @@ test_invalid_cloudtrail_s3_data_logging_no_trails {
   report := regula.report with input as inputs.invalid_cloudtrail_s3_data_logging_no_trails_infra.mock_plan_input
   resources := report.rules.cfn_s3_cloudtrail_s3_data_logging_read.resources
 
-  count(resources) == 3
-  resources["Bucket1"].valid == false
-  resources["Bucket2"].valid == false
-  resources["Bucket3"].valid == false
+  # The rule shouldn't evaluate any of the buckets when there are no trails.
+  count(resources) == 0
 }
 
 test_invalid_cloudtrail_s3_data_logging_trail_no_data_events {

--- a/tests/rules/cfn/s3/cloudtrail_s3_data_logging_write_test.rego
+++ b/tests/rules/cfn/s3/cloudtrail_s3_data_logging_write_test.rego
@@ -76,10 +76,8 @@ test_invalid_cloudtrail_s3_data_logging_no_trails {
   report := regula.report with input as inputs.invalid_cloudtrail_s3_data_logging_no_trails_infra.mock_plan_input
   resources := report.rules.cfn_s3_cloudtrail_s3_data_logging_write.resources
 
-  count(resources) == 3
-  resources["Bucket1"].valid == false
-  resources["Bucket2"].valid == false
-  resources["Bucket3"].valid == false
+  # The rule shouldn't evaluate any of the buckets when there are no trails.
+  count(resources) == 0
 }
 
 test_invalid_cloudtrail_s3_data_logging_trail_no_data_events {


### PR DESCRIPTION
This change updates `rules/cfn/s3/cloudtrail_s3_data_logging_read.rego` and `rules/cfn/s3/cloudtrail_s3_data_logging_write.rego` to not evaluate when the template does not contain any trails. We cannot provide a definitive result when these resources are not evaluated together, like when they're defined in different templates.