### PR TITLE
[RM-5293] Update report output format

### DIFF
--- a/bin/regula
+++ b/bin/regula
@@ -106,6 +106,6 @@ elif [[ "$INPUT_TYPE" == "cloudformation" ]]; then
 fi
 
 # Finally, run OPA on the result to get out our report.
-opa eval --input "$INPUT_PATH" \
+opa eval --format=pretty --input "$INPUT_PATH" \
     "${D_REGO_PATHS[@]}" \
     'data.fugue.regula.report'

--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -41,7 +41,8 @@ allow_resource(resource) = ret {
     "valid": true,
     "id": resource.id,
     "message": "",
-    "type": resource._type
+    "type": resource._type,
+    "provider": resource._provider,
   }
 }
 
@@ -54,7 +55,8 @@ deny_resource_with_message(resource, message) = ret {
     "valid": false,
     "id": resource.id,
     "message": message,
-    "type": resource._type
+    "type": resource._type,
+    "provider": resource._provider,
   }
 }
 
@@ -67,7 +69,11 @@ missing_resource_with_message(resource_type, message) = ret {
     "valid": false,
     "id": "",
     "message": message,
-    "type": resource_type
+    "type": resource_type,
+    # TODO: We're falling back to a blank provider here to avoid breaking the API.
+    # We should aim to change the API for these result functions to take a single
+    # object. Then we can add new fields w/o breaking anyone's usage.
+    "provider": "",
   }
 }
 

--- a/lib/fugue/resource_view/cloudformation.rego
+++ b/lib/fugue/resource_view/cloudformation.rego
@@ -21,6 +21,7 @@ resource_view[id] = ret {
   ret := json.patch(properties, [
     {"op": "add", "path": ["id"], "value": id},
     {"op": "add", "path": ["_type"], "value": resource.Type},
+    {"op": "add", "path": ["_provider"], "value": "aws"},
   ])
 }
 

--- a/lib/fugue/resource_view/terraform.rego
+++ b/lib/fugue/resource_view/terraform.rego
@@ -103,6 +103,7 @@ planned_values_resources = {id: ret |
   ret = json.patch(resource_values(resource), [
     {"op": "add", "path": ["id"], "value": id},
     {"op": "add", "path": ["_type"], "value": resource.type},
+    {"op": "add", "path": ["_provider"], "value": resource.provider_name},
   ])
 }
 

--- a/tests/examples/aws/ec2_t2_only_test.rego
+++ b/tests/examples/aws/ec2_t2_only_test.rego
@@ -11,18 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package tests.rules.ec2_t2_only
+package rules.ec2_t2_only
 
-import data.rules.ec2_t2_only
 import data.tests.examples.aws.inputs.ec2_t2_only_infra
 
 test_t2_only {
   resources = ec2_t2_only_infra.mock_resources
-  not ec2_t2_only.allow with input as resources["aws_instance.invalid"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_micro"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_small"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_medium"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_large"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_xlarge"]
-  ec2_t2_only.allow with input as resources["aws_instance.valid_2xlarge"]
+  not allow with input as resources["aws_instance.invalid"]
+  allow with input as resources["aws_instance.valid_micro"]
+  allow with input as resources["aws_instance.valid_small"]
+  allow with input as resources["aws_instance.valid_medium"]
+  allow with input as resources["aws_instance.valid_large"]
+  allow with input as resources["aws_instance.valid_xlarge"]
+  allow with input as resources["aws_instance.valid_2xlarge"]
 }

--- a/tests/examples/aws/iam_password_length_test.rego
+++ b/tests/examples/aws/iam_password_length_test.rego
@@ -11,18 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package tests.rules.iam_password_length
+package rules.iam_password_length
 
-import data.fugue.regula
-import data.tests.examples.aws.inputs.iam_password_length_infra.mock_plan_input
+import data.fugue.resource_view.resource_view_input
+import data.tests.examples.aws.inputs.iam_password_length_infra.mock_input
 
 test_iam_password_length {
-  report := regula.report with input as mock_plan_input
-  resources := report.rules.iam_password_length.resources
-  resources["aws_iam_account_password_policy.valid"].valid == true
-  resources["aws_iam_account_password_policy.invalid_1"].valid == false
-  resources["aws_iam_account_password_policy.invalid_2"].valid == false
+  pol = policy with input as mock_input
+  by_resource_id = {p.id: p.valid | pol[p]}
+  by_resource_id["aws_iam_account_password_policy.valid"] == true
+  by_resource_id["aws_iam_account_password_policy.invalid_1"] == false
+  by_resource_id["aws_iam_account_password_policy.invalid_2"] == false
 
-  empty_report := regula.report with input as {"terraform_version": "0.12.18"}
-  empty_report.rules.iam_password_length.valid == false
+  empty_policy = policy with input as empty_input
+  empty_policy[_].valid == false
+}
+
+empty_input = ret {
+  ret = resource_view_input with input as {"terraform_version": "0.12.18"}
 }

--- a/tests/examples/aws/tag_all_resources_test.rego
+++ b/tests/examples/aws/tag_all_resources_test.rego
@@ -11,23 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package tests.rules.tag_all_resources
+package rules.tag_all_resources
 
-import data.fugue.regula
-import data.tests.examples.aws.inputs.tag_all_resources_infra.mock_plan_input
+import data.tests.examples.aws.inputs.tag_all_resources_infra.mock_input
 
 test_tag_all_resources {
-  report := regula.report with input as mock_plan_input
-  resources := report.rules.tag_all_resources.resources
+  pol = policy with input as mock_input
+  by_resource_id = {p.id: {"valid": p.valid, "message": p.message} | pol[p]}
 
-  resources["aws_vpc.invalid"].valid == false
-  re_match("too short", resources["aws_s3_bucket.invalid"].message)
+  by_resource_id["aws_vpc.invalid"].valid == false
+  re_match("too short", by_resource_id["aws_s3_bucket.invalid"].message)
 
-  resources["aws_s3_bucket.invalid"].valid == false
-  re_match("too short", resources["aws_s3_bucket.invalid"].message)
+  by_resource_id["aws_s3_bucket.invalid"].valid == false
+  re_match("too short", by_resource_id["aws_s3_bucket.invalid"].message)
 
-  resources["aws_vpc.untagged"].valid == false
-  re_match("No tags", resources["aws_vpc.untagged"].message)
+  by_resource_id["aws_vpc.untagged"].valid == false
+  re_match("No tags", by_resource_id["aws_vpc.untagged"].message)
 
-  resources["aws_vpc.valid"].valid == true
+  by_resource_id["aws_vpc.valid"].valid == true
 }

--- a/tests/examples/aws/useast1_only_test.rego
+++ b/tests/examples/aws/useast1_only_test.rego
@@ -11,30 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package tests.rules.useast1_only
+package rules.useast1_only
 
-import data.fugue.regula
-import data.tests.examples.aws.inputs.useast1_only_infra.mock_plan_input
+import data.fugue.resource_view.resource_view_input
+import data.tests.examples.aws.inputs.useast1_only_infra.mock_input
 
 test_useast1_only {
-  report := regula.report with input as mock_plan_input
-  report.rules.useast1_only.valid == true
+  pol = policy with input as mock_input
+  # We're only producing a result when provider region != "us-east-1"
+  pol == set()
 }
 
 test_useast2_only {
-  report := regula.report with input as mock_useast2_input
-  report.rules.useast1_only.valid == false
+  pol = policy with input as mock_useast2_input
+  pol[_].valid == false
 }
 
-mock_useast2_input = {
-  "terraform_version": "0.12.18",
-  "configuration": {
-    "provider_config": {
-      "aws": {
-        "name": "aws",
-        "expressions": {
-          "region": {
-            "constant_value": "us-east-2"
+mock_useast2_input = ret {
+  ret = resource_view_input with input as {
+    "terraform_version": "0.12.18",
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "expressions": {
+            "region": {
+              "constant_value": "us-east-2"
+            }
           }
         }
       }

--- a/tests/lib/fugue_regula_report_test.rego
+++ b/tests/lib/fugue_regula_report_test.rego
@@ -29,8 +29,12 @@ mock_rules = {
       "custom": {
         "controls": {
           "MOCK": ["MOCK_1.2.3"]
-        }
-      }
+        },
+        "severity": "High"
+      },
+      "id": "FG_R00001",
+      "title": "Always pass",
+      "description": "This rule always passes"
     },
     "resource_type": "aws_ebs_volume",
     "allow": true
@@ -46,23 +50,117 @@ report = ret {
   ret = regula.report with input as mock_plan_input with data.rules as mock_rules
 }
 
+contains_result(arr, result) {
+  r = arr[_]
+  result == r
+}
+
 # Test the report.
 test_report {
-  report.summary == {
-    "controls_failed": 0,
-    "controls_passed": 1,
-    "rules_failed": 1,
-    "rules_passed": 1,
-    "valid": false,
-  }
+  count(expected_report.rule_results) == count(report.rule_results)
+  all([c | r = expected_report.rule_results[_]; c = contains_result(report.rule_results, r)])
+  expected_report.summary == report.summary
+}
 
-  report.controls == {
-    "MOCK_1.2.3": {
-      "rules": {"always_pass"},
-      "valid": true,
+expected_report = {
+  "rule_results": [
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.good",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "pass",
+      "rule_name": "always_pass",
+      "platform": "terraform",
+      "rule_id": "FG_R00001",
+      "rule_summary": "Always pass",
+      "rule_description": "This rule always passes",
+      "rule_severity": "high",
+      "controls": {"MOCK_1.2.3"}
+    },
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.missing",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "pass",
+      "rule_name": "always_pass",
+      "platform": "terraform",
+      "rule_id": "FG_R00001",
+      "rule_summary": "Always pass",
+      "rule_description": "This rule always passes",
+      "rule_severity": "high",
+      "controls": {"MOCK_1.2.3"}
+    },
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.bad",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "pass",
+      "rule_name": "always_pass",
+      "platform": "terraform",
+      "rule_id": "FG_R00001",
+      "rule_summary": "Always pass",
+      "rule_description": "This rule always passes",
+      "rule_severity": "high",
+      "controls": {"MOCK_1.2.3"}
+    },
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.good",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "fail",
+      "rule_name": "always_fail",
+      "platform": "terraform",
+      "rule_id": "",
+      "rule_summary": "",
+      "rule_description": "",
+      "rule_severity": "unknown",
+      "controls": set()
+    },
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.missing",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "fail",
+      "rule_name": "always_fail",
+      "platform": "terraform",
+      "rule_id": "",
+      "rule_summary": "",
+      "rule_description": "",
+      "rule_severity": "unknown",
+      "controls": set()
+    },
+    {
+      "provider": "aws",
+      "resource_id": "aws_ebs_volume.bad",
+      "resource_type": "aws_ebs_volume",
+      "rule_message": "",
+      "rule_result": "fail",
+      "rule_name": "always_fail",
+      "platform": "terraform",
+      "rule_id": "",
+      "rule_summary": "",
+      "rule_description": "",
+      "rule_severity": "unknown",
+      "controls": set()
+    }
+  ],
+  "summary": {
+    "rule_results": {
+      "pass": 3,
+      "fail": 3
+    },
+    "severities": {
+      "critical": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "informational": 0,
+      "unknown": 3,
     }
   }
-
-  re_match("1 rules passed, 1 rules failed", report.message)
-  re_match("Rule always_fail failed for resource", report.message)
 }

--- a/tests/lib/fugue_regula_test.rego
+++ b/tests/lib/fugue_regula_test.rego
@@ -16,7 +16,8 @@ package fugue.regula
 # Simple resource used for testing.
 testutil_resource = {
   "id": "testutil_resource",
-  "_type": "aws_elb_volume"
+  "_type": "aws_elb_volume",
+  "_provider": "aws"
 }
 
 test_judgement_from_allow_denies_01 {

--- a/tests/lib/fugue_resource_view_01_test.rego
+++ b/tests/lib/fugue_resource_view_01_test.rego
@@ -32,13 +32,15 @@ test_resource_view_01 {
       "logging": [],
       "lifecycle_rule": [],
       "_type": "aws_s3_bucket",
+      "_provider": "aws",
       "force_destroy": false
     },
     "aws_s3_bucket_policy.example": {
       "id": "aws_s3_bucket_policy.example",
       "bucket": "aws_s3_bucket.example",
       "policy": "data.aws_iam_policy_document.example",
-      "_type": "aws_s3_bucket_policy"
+      "_type": "aws_s3_bucket_policy",
+      "_provider": "aws",
     },
     "data.aws_iam_policy_document.example": {
       "id": "data.aws_iam_policy_document.example",
@@ -62,7 +64,8 @@ test_resource_view_01 {
       "source_json": null,
       "version": null,
       "policy_id": null,
-      "_type": "aws_iam_policy_document"
+      "_type": "aws_iam_policy_document",
+      "_provider": "aws",
     }
   }
 }

--- a/tests/lib/fugue_resource_view_02_test.rego
+++ b/tests/lib/fugue_resource_view_02_test.rego
@@ -32,6 +32,7 @@ test_resource_view_02 {
       "logging": [],
       "lifecycle_rule": [],
       "_type": "aws_s3_bucket",
+      "_provider": "aws",
       "force_destroy": false
     },
     "data.aws_iam_policy_document.example": {
@@ -59,7 +60,8 @@ test_resource_view_02 {
       "source_json": null,
       "version": null,
       "policy_id": null,
-      "_type": "aws_iam_policy_document"
+      "_type": "aws_iam_policy_document",
+      "_provider": "aws",
     },
     "aws_iam_policy.example": {
       "id": "aws_iam_policy.example",
@@ -67,6 +69,7 @@ test_resource_view_02 {
       "policy": "data.aws_iam_policy_document.example",
       "path": "/",
       "_type": "aws_iam_policy",
+      "_provider": "aws",
       "name_prefix": null
     }
   }

--- a/tests/lib/fugue_resource_view_03_test.rego
+++ b/tests/lib/fugue_resource_view_03_test.rego
@@ -19,6 +19,7 @@ test_resource_view_03 {
   resource_view_03_infra.mock_resources == {
      "azurerm_monitor_log_profile.main": {
       "_type": "azurerm_monitor_log_profile",
+      "_provider": "azurerm",
       "categories": [
         "Action",
         "Delete",
@@ -42,6 +43,7 @@ test_resource_view_03 {
     },
     "azurerm_resource_group.main": {
       "_type": "azurerm_resource_group",
+      "_provider": "azurerm",
       "id": "azurerm_resource_group.main",
       "location": "westeurope",
       "name": "main",
@@ -50,6 +52,7 @@ test_resource_view_03 {
     },
     "azurerm_storage_account.main": {
       "_type": "azurerm_storage_account",
+      "_provider": "azurerm",
       "account_kind": "StorageV2",
       "account_replication_type": "GRS",
       "account_tier": "Standard",

--- a/tests/lib/fugue_resource_view_cloudformation_test.rego
+++ b/tests/lib/fugue_resource_view_cloudformation_test.rego
@@ -29,12 +29,14 @@ Resources:
     "MySecurityGroup": {
       "id": "MySecurityGroup",
       "Vpc": "MyVpc",
-      "_type": "SecurityGroupId"
+      "_type": "SecurityGroupId",
+      "_provider": "aws",
     },
     "MyVpc": {
       "id": "MyVpc",
       "Name": "bar",
-      "_type": "Vpc"
+      "_type": "Vpc",
+      "_provider": "aws",
     }
   }
 }
@@ -60,7 +62,8 @@ Resources:
       "id": "MyServer",
       "TheHost": "0.0.0.0",
       "ThePort": 80,
-      "_type": "Server"
+      "_type": "Server",
+      "_provider": "aws",
     }
   }
 }
@@ -87,10 +90,12 @@ Resources:
   rv == {
     "LoggingBucket": {
       "_type": "AWS::S3::Bucket",
+      "_provider": "aws",
       "id": "LoggingBucket"
     },
     "CloudTrailLogging": {
       "_type": "AWS::CloudTrail::Trail",
+      "_provider": "aws",
       "EventSelectors": [
         {
           "DataResources": [
@@ -137,6 +142,7 @@ Resources:
   rv == {
     "CloudTrailLogging": {
       "_type": "AWS::CloudTrail::Trail",
+      "_provider": "aws",
       "EventSelectors": [
         {
           "DataResources": [

--- a/tests/lib/fugue_resource_view_modules_test.rego
+++ b/tests/lib/fugue_resource_view_modules_test.rego
@@ -605,7 +605,8 @@ expected_resource_view = {
     "cidr_block": "10.0.0.0/16",
     "instance_tenancy": "default",
     "enable_dns_support": true,
-    "_type": "aws_vpc"
+    "_type": "aws_vpc",
+    "_provider": "aws",
   },
   "module.child1.module.grandchild1.aws_vpc.grandchild": {
     "id": "module.child1.module.grandchild1.aws_vpc.grandchild",
@@ -614,7 +615,8 @@ expected_resource_view = {
     "cidr_block": "10.0.0.0/16",
     "instance_tenancy": "default",
     "enable_dns_support": true,
-    "_type": "aws_vpc"
+    "_type": "aws_vpc",
+    "_provider": "aws",
   },
   "module.child2.aws_vpc.child": {
     "id": "module.child2.aws_vpc.child",
@@ -623,7 +625,8 @@ expected_resource_view = {
     "cidr_block": "10.0.0.0/16",
     "instance_tenancy": "default",
     "enable_dns_support": true,
-    "_type": "aws_vpc"
+    "_type": "aws_vpc",
+    "_provider": "aws",
   },
   "module.child2.aws_security_group.child": {
     "id": "module.child2.aws_security_group.child",
@@ -633,6 +636,7 @@ expected_resource_view = {
     "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild",
     "timeouts": null,
     "_type": "aws_security_group",
+    "_provider": "aws",
     "name_prefix": null
   },
   "aws_security_group.parent": {
@@ -643,6 +647,7 @@ expected_resource_view = {
     "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild",
     "timeouts": null,
     "_type": "aws_security_group",
+    "_provider": "aws",
     "name_prefix": null
   },
   "module.child1.aws_vpc.child": {
@@ -652,7 +657,8 @@ expected_resource_view = {
     "cidr_block": "10.0.0.0/16",
     "instance_tenancy": "default",
     "enable_dns_support": true,
-    "_type": "aws_vpc"
+    "_type": "aws_vpc",
+    "_provider": "aws",
   },
   "module.child1.module.grandchild1.aws_security_group.grandchild": {
     "id": "module.child1.module.grandchild1.aws_security_group.grandchild",
@@ -662,6 +668,7 @@ expected_resource_view = {
     "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild",
     "timeouts": null,
     "_type": "aws_security_group",
+    "_provider": "aws",
     "name_prefix": null
   }
 }

--- a/tests/lib/fugue_resource_view_test.rego
+++ b/tests/lib/fugue_resource_view_test.rego
@@ -42,6 +42,7 @@ test_resource_view {
     "aws_ebs_volume.bad": {
       "id": "aws_ebs_volume.bad",
       "_type": "aws_ebs_volume",
+      "_provider": "aws",
       "availability_zone": "us-west-2a",
       "size": 8,
       "tags": null


### PR DESCRIPTION
### Please do not merge yet

This is a work-in-progress PR with updates to the report output format. This will be a breaking change for users and should be be shipped separately from the CloudFormation work. Example output of `./bin/regula` so far:

```json
{
  "rule_results": [
    {
      "controls": [
        "CIS-AWS_v1.3.0_1.20"
      ],
      "platform": "cloudformation",
      "provider": "aws",
      "resource_id": "Bucket",
      "resource_type": "AWS::S3::Bucket",
      "rule_description": "S3 buckets should have all `block public access` options enabled. AWS's S3 Block Public Access feature has four settings: BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, and RestrictPublicBuckets. All four settings should be enabled to help prevent the risk of a data breach.",
      "rule_id": "FG_R00229",
      "rule_message": "",
      "rule_name": "cfn_s3_block_public_access",
      "rule_result": "pass",
      "rule_severity": "high",
      "rule_summary": "S3 buckets should have all `block public access` options enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1"
      ],
      "platform": "cloudformation",
      "provider": "aws",
      "resource_id": "Bucket",
      "resource_type": "AWS::S3::Bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "cfn_s3_encryption",
      "rule_result": "fail",
      "rule_severity": "high",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.2"
      ],
      "platform": "cloudformation",
      "provider": "aws",
      "resource_id": "Bucket",
      "resource_type": "AWS::S3::Bucket",
      "rule_description": "S3 bucket policies should only allow requests that use HTTPS. To protect data in transit, an S3 bucket policy should deny all HTTP requests to its objects and allow only HTTPS requests. HTTPS uses Transport Layer Security (TLS) to encrypt data, which preserves integrity and prevents tampering.",
      "rule_id": "FG_R00100",
      "rule_message": "",
      "rule_name": "cfn_s3_https_access",
      "rule_result": "fail",
      "rule_severity": "medium",
      "rule_summary": "S3 bucket policies should only allow requests that use HTTPS"
    }
  ],
  "summary": {
    "rule_results": {
      "fail": 2,
      "pass": 1
    },
    "severities": {
      "critical": 0,
      "high": 1,
      "informational": 0,
      "low": 0,
      "medium": 1,
      "unknown": 0
    }
  }
}
```

### What's missing

We'll need to add fields for file names and the `waived` status once those underlying features are implemented.
