### PR TITLE
Remove quotes in math expression in regula script

### DIFF
--- a/bin/regula
+++ b/bin/regula
@@ -153,7 +153,7 @@ else
     filename="${INPUT_PATHS[$i]}"
     echo "{\"filename\":\"$filename\",\"content\":" >>"$INPUT_PATH"
     cat "${PROCESSED_INPUT_PATHS[$i]}" >>"$INPUT_PATH"
-    if [[ $(("$i" + 1)) == "${#PROCESSED_INPUT_PATHS[@]}" ]]; then
+    if [[ $(($i + 1)) == "${#PROCESSED_INPUT_PATHS[@]}" ]]; then
       echo "}]" >>"$INPUT_PATH"
     else
       echo "}," >>"$INPUT_PATH"


### PR DESCRIPTION
This PR fixes a compatibility issue with bash 3.2 where the quotes around our index variable caused this arithmetic expansion to fail.