### PR TITLE
Update docker to use new entrypoint style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY lib /opt/regula/lib
 COPY rules /opt/regula/rules
 COPY bin/regula /usr/local/bin
 
-ENTRYPOINT ["regula", "-", "/opt/regula"]
+ENTRYPOINT ["regula", "-d", "/opt/regula"]

--- a/README.md
+++ b/README.md
@@ -104,18 +104,19 @@ Regula is available as a Docker image on DockerHub [here](https://hub.docker.com
 
 To run Regula on a CloudFormation template or Terraform plan file, use the following command:
 
-    docker run --rm -i fugue/regula < [IAC_TEMPLATE]
+    docker run --rm -i fugue/regula - < [IAC_TEMPLATE]
 
 `IAC_TEMPLATE` is the specific code file you want Regula to check.
+It is passed on standard input (`-`) to regula.
 
 To run Regula on Terraform HCL files, use the following command:
 
-    docker run --rm --entrypoint regula \
-    --volume [HCL_DIRECTORY]:/workspace \
-    -e AWS_ACCESS_KEY_ID=XXXXXX \
-    -e AWS_SECRET_ACCESS_KEY=XXXXXX \
-    -e AWS_DEFAULT_REGION=xx-xxxx-x \
-    fugue/regula /workspace /opt/regula
+    docker run --rm \
+        --volume [HCL_DIRECTORY]:/workspace \
+        -e AWS_ACCESS_KEY_ID=XXXXXX \
+        -e AWS_SECRET_ACCESS_KEY=XXXXXX \
+        -e AWS_DEFAULT_REGION=xx-xxxx-x \
+        fugue/regula /workspace
 
 `HCL_DIRECTORY` is the location of the Terraform HCL files you want Regula to check. This command creates a volume for the Docker container to access these files, so that a Terraform plan file can be generated.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ To run Regula on Terraform HCL files, use the following command:
 
 `HCL_DIRECTORY` is the location of the Terraform HCL files you want Regula to check. This command creates a volume for the Docker container to access these files, so that a Terraform plan file can be generated.
 
+When integrating this in a CI pipeline, we recommend pinning the regula version, e.g. `docker run fugue/regula:v0.7.0`.
+
 ## Regula rules
 
 Regula rules are written in [Rego] and use the same format as [Fugue Custom Rules]. This means there are (currently) two kinds of rules: simple rules and advanced rules.


### PR DESCRIPTION
Since the input file is no longer specified first, this allows us to add
arguments without having to overwrite the entrypoint.  This does mean that
"simple" usage now requires the `-` parameter:

    docker run -i regula:latest - <some_file.cfn

I think this is outweighed by the advantages: this makes it easier to pass in
other arguments, without having to re-specify `/opt/regula/`.  For example:

    docker run --rm \
        --volume [HCL_DIRECTORY]:/workspace \
        fugue/regula \
        /workspace

Where we needed the following monstrosity before:

    docker run --rm \
        --entrypoint regula \
        --volume [HCL_DIRECTORY]:/workspace \
        fugue/regula \
        /workspace \
        /opt/regula