### PR TITLE
[RM-5341] Add parameter based versions for fugue.{allow,deny}

### DIFF
--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -83,10 +83,7 @@ missing(params) = ret {
     "id": "",
     "type": params.resource_type,
     "message": object.get(params, "message", "invalid"),
-    # TODO: We're falling back to a blank provider here to avoid breaking the API.
-    # We should aim to change the API for these result functions to take a single
-    # object. Then we can add new fields w/o breaking anyone's usage.
-    "provider": "",
+    "provider": object.get(params, "provider", ""),
   }
 }
 

--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -37,39 +37,52 @@ resources(rt) = ret {
 }
 
 allow_resource(resource) = ret {
-  ret = {
+  ret := allow({"resource": resource})
+}
+
+allow(params) = ret {
+  ret := {
     "valid": true,
-    "id": resource.id,
-    "message": "",
-    "type": resource._type,
-    "provider": resource._provider,
+    "id": params.resource.id,
+    "type": params.resource._type,
+    "message": object.get(params, "message", ""),
+    "provider": params.resource._provider,
   }
 }
 
 deny_resource(resource) = ret {
-  ret = deny_resource_with_message(resource, "")
+  ret := deny({"resource": resource})
 }
 
 deny_resource_with_message(resource, message) = ret {
-  ret = {
+  ret := deny({"resource": resource, "message": message})
+}
+
+deny(params) = ret {
+  ret := {
     "valid": false,
-    "id": resource.id,
-    "message": message,
-    "type": resource._type,
-    "provider": resource._provider,
+    "id": params.resource.id,
+    "type": params.resource._type,
+    "message": object.get(params, "message", ""),
+    "attribute": object.get(params, "attribute", null),
+    "provider": params.resource._provider,
   }
 }
 
 missing_resource(resource_type) = ret {
-  ret = missing_resource_with_message(resource_type, "")
+  ret := missing({"resource_type": resource_type})
 }
 
 missing_resource_with_message(resource_type, message) = ret {
-  ret = {
+  ret := missing({"resource_type": resource_type, "message": message})
+}
+
+missing(params) = ret {
+  ret := {
     "valid": false,
     "id": "",
-    "message": message,
-    "type": resource_type,
+    "type": params.resource_type,
+    "message": object.get(params, "message", "invalid"),
     # TODO: We're falling back to a blank provider here to avoid breaking the API.
     # We should aim to change the API for these result functions to take a single
     # object. Then we can add new fields w/o breaking anyone's usage.


### PR DESCRIPTION
We currently have the following functions available to advanced rules:

    fugue.allow_resource(resource)
    fugue.deny_resource(resource)
    fugue.deny_resource_with_message(resource, message)
    fugue.missing_resource(resource_type)
    fugue.missing_resource_with_message(resource_type, message)

We would like to point out _where_ resources are invalid.  This is expressed as
a Rego path to an attribute (e.g. `["port"]` or `["ingress", 0]`).

However, Rego doesn't allow function overloading, and we don't want to keep
adding new versions of this functions using different `_with_xxx` combinations.

This patch adds three new functions:

    fugue.allow({"resource": resource})
    fugue.deny({"resource": resource})
    fugue.missing({"resource_type": resource_type})

These builtins all take more parameters (`message`, `attribute`, ...) in the
object and we can add new ones without breaking the API.