### PR TITLE
[RM-5590] Fix module detection in terraform resource view

### DIFF
--- a/lib/fugue/resource_view/terraform.rego
+++ b/lib/fugue/resource_view/terraform.rego
@@ -122,7 +122,7 @@ configuration_modules[module_path] = ret {
   module = val[module_name]
   is_object(module)
   _ = module.resources
-  all([string_is_module_calls(k) | path[i] = k; i % 3 == 0])
+  all([b | path[i] = k; i % 3 == 1; b := (k == "module_calls")])
   module_path = [k | path[i] = k; i % 3 == 2]
 
   # Calculate input variables used in this module.
@@ -134,10 +134,6 @@ configuration_modules[module_path] = ret {
 
   ret = [vars, module]
 }
-
-# Utility to work around a fregot parsing bug.  Try inlining this and see what
-# happens.
-string_is_module_calls(k) {k == "module_calls"}
 
 # Calculate outputs into a globally qualified map.
 configuration_module_outputs[qualified_var] = qualified_val {


### PR DESCRIPTION
For some complex terraform plans involving modules, we were seeing the following
error:

    object keys must be unique

This was an error in `configuration_modules`, which walks a large tree and
identifies possible modules.  We were identifying modules by different
properties:

1.  Is an object
2.  The shape of the path
3.  Has a `.resources` attribute

However, check (2) was broken.  This lead to us misidentifying a common resource
as a module (since it also had a `.resources` field); in turn causing two
results (the common resource and the actual module) for the same module path,
leading to the inconsistency error.

Why was check (2) broken?  It had been broken since it was merged, but because
OPA wasn't enforcing the consistency check until recently, we didn't notice.

We were using `all` for (2), which has a number of gotchas.  In particular, code
like this:

    all([foo(x) | x = ...])

Works if `foo(x)` either returns `true` or `false`.  However, if `foo` is
defined as:

    foo(x) {
        x > 3  # For example
    }

It does *not* work the way you would assume it works!  It is evaluated as:

       all([foo(x) | x = 2])
    => all([head | x = 2; head = foo(x)])  # Desugar for clarity
    => all([head | head = foo(2)])         # Inline x
    => all([])                             # foo(2) is the empty set!
    => true                                # all([]) is true

So one way to work around this would be to ensure `foo` always returns a boolean
result rather than the empty set:

    foo(x) = true {
        x > 3  # For example
    } else = false {
        true
    }

In this specific case, that wasn't necessary since we could just inline the
check.