### PR TITLE
Fix bug in tag_all_resources example rule

### DIFF
--- a/examples/aws/tag_all_resources.rego
+++ b/examples/aws/tag_all_resources.rego
@@ -76,9 +76,10 @@ is_tagged(resource) {
 
 is_improperly_tagged(resource) = msg {
   # Any tag value has less than 6 characters.
-  resource.tags[key] = val
-  count(val) < 6
-  msg = sprintf("Tag %s is too short", [key])
+  too_short = [k | v = resource.tags[k]; count(v) < 6]
+  count(too_short) > 0
+  keys = concat(", ", too_short)
+  msg = sprintf("Values for these tags are too short: %s", [keys])
 } else = "No tags found" {
   # The resource is not tagged at all.
   not is_tagged(resource)


### PR DESCRIPTION
This PR fixes an issue where multiple tags under 6 characters results in a `functions must not produce multiple outputs for same inputs` error in this example rule.