### PR TITLE
Small bug fixes

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -305,13 +305,22 @@ func (c *HclConfiguration) renderResource(
 
 	// `provider` may be explicitly set.
 	if provider, ok := properties["provider"]; ok {
-		properties["_provider"] = provider
+		properties["_provider"] = formatProvider(provider)
 		delete(properties, "provider")
 	} else {
-		properties["_provider"] = resource.Provider.ForDisplay()
+		properties["_provider"] = formatProvider(resource.Provider.ForDisplay())
 	}
 
 	return properties
+}
+
+func formatProvider(provider interface{}) interface{} {
+	p, ok := provider.(string)
+	if !ok {
+		return provider
+	}
+	split := strings.Split(p, "/")
+	return split[len(split)-1]
 }
 
 func (c *HclConfiguration) getResource(id string) (*configs.Resource, bool) {

--- a/pkg/loader/tf_test/example-terraform-modules.json
+++ b/pkg/loader/tf_test/example-terraform-modules.json
@@ -3,43 +3,43 @@
     "hcl_resource_view_version": "0.0.1",
     "resources": {
       "aws_security_group.parent": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_security_group",
         "id": "aws_security_group.parent",
         "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild"
       },
       "aws_vpc.parent": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_vpc",
         "cidr_block": "10.0.0.0/16",
         "id": "aws_vpc.parent"
       },
       "module.child1.aws_vpc.child": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_vpc",
         "cidr_block": "10.0.0.0/16",
         "id": "module.child1.aws_vpc.child"
       },
       "module.child1.module.grandchild1.aws_security_group.grandchild": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_security_group",
         "id": "module.child1.module.grandchild1.aws_security_group.grandchild",
         "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild"
       },
       "module.child1.module.grandchild1.aws_vpc.grandchild": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_vpc",
         "cidr_block": "10.0.0.0/16",
         "id": "module.child1.module.grandchild1.aws_vpc.grandchild"
       },
       "module.child2.aws_security_group.child": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_security_group",
         "id": "module.child2.aws_security_group.child",
         "vpc_id": "module.child1.module.grandchild1.aws_vpc.grandchild"
       },
       "module.child2.aws_vpc.child": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_vpc",
         "cidr_block": "10.0.0.0/16",
         "id": "module.child2.aws_vpc.child"

--- a/pkg/loader/tf_test/file.json
+++ b/pkg/loader/tf_test/file.json
@@ -3,7 +3,7 @@
     "hcl_resource_view_version": "0.0.1",
     "resources": {
       "aws_s3_bucket.trail_bucket": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_s3_bucket",
         "force_destroy": true,
         "id": "aws_s3_bucket.trail_bucket",

--- a/pkg/loader/tf_test/resource-local-ref.json
+++ b/pkg/loader/tf_test/resource-local-ref.json
@@ -3,7 +3,7 @@
     "hcl_resource_view_version": "0.0.1",
     "resources": {
       "aws_s3_bucket.trail_bucket": {
-        "_provider": "hashicorp/aws",
+        "_provider": "aws",
         "_type": "aws_s3_bucket",
         "bucket_prefix": "hello",
         "force_destroy": true,

--- a/pkg/rego/load.go
+++ b/pkg/rego/load.go
@@ -100,6 +100,9 @@ func LoadOSFiles(paths []string, cb func(r RegoFile) error) error {
 			}
 			continue
 		}
+		if ext := filepath.Ext(path); !opaExts[ext] {
+			continue
+		}
 		file, err := newRegoFile(fsys, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR includes two small bug fixes:
* Exclude the `hashicorp/` prefix in the provider field in the TF loader. This change makes the behavior match what you'd get from evaluating an equivalent Terraform plan.
* Ignore non-rego files when loading an individual rego file. I was already checking against the `opaExts` set when a directory gets passed to `regula test`, `regula repl`, `regula run --include`, etc. But, I forgot to do the same when an individual file is specified.