### PR TITLE
Include filepath in JUnit test case names

### DIFF
--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -98,6 +98,7 @@ func (o RegulaOutput) ExceedsSeverity(severity Severity) bool {
 }
 
 type ResourceResults struct {
+	Filepath     string
 	ResourceID   string
 	ResourceType string
 	Results      []RuleResult
@@ -144,6 +145,7 @@ func (o RegulaOutput) AggregateByFilepath() ResultsByFilepath {
 		resourceResults, ok := filepathResults.Results[r.ResourceID]
 		if !ok {
 			resourceResults = ResourceResults{
+				Filepath:     r.Filepath,
 				ResourceID:   r.ResourceID,
 				ResourceType: r.ResourceType,
 				Results:      []RuleResult{},

--- a/pkg/reporter/junit.go
+++ b/pkg/reporter/junit.go
@@ -18,6 +18,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 func JUnitReporter(o *RegulaOutput) (string, error) {
@@ -49,8 +50,12 @@ func (r ResourceResults) ToTestCase() JUnitTestCase {
 			})
 		}
 	}
+	caseName := strings.Join([]string{
+		r.Filepath,
+		r.ResourceID,
+	}, "#")
 	testCase := JUnitTestCase{
-		Name:       r.ResourceID,
+		Name:       caseName,
 		ClassName:  r.ResourceType,
 		Assertions: len(r.Results),
 	}


### PR DESCRIPTION
CircleCI doesn't show the test suite names from JUnit XML. This PR adds the file path to the JUnit test case name in the JUnit output format. An example of what this will look like in CircleCI is:

### This would be in the top panel listing test failures
```
src/cloudformation.yaml#SomeResource
```

### This would be shown as the header for the failure detail.
```
src/cloudformation.yaml#SomeResource - AWS::Service::ResourceType
```

This behavior is similar to some scripts we've used in the past.