### PR TITLE
Add input and resource type to cfn nacl rules

### DIFF
--- a/rego/rules/cfn/vpc/nacl_ingress_22.rego
+++ b/rego/rules/cfn/vpc/nacl_ingress_22.rego
@@ -32,6 +32,9 @@ __rego__metadoc__ := {
 
 nacls = fugue.resources("AWS::EC2::NetworkAcl")
 
+input_type = "cloudformation"
+resource_type = "MULTIPLE"
+
 policy[p] {
   nacl = nacls[_]
   not nacl_library.nacl_ingress_zero_cidr_to_port(nacl.id, 22)

--- a/rego/rules/cfn/vpc/nacl_ingress_3389.rego
+++ b/rego/rules/cfn/vpc/nacl_ingress_3389.rego
@@ -32,6 +32,9 @@ __rego__metadoc__ := {
 
 nacls = fugue.resources("AWS::EC2::NetworkAcl")
 
+input_type = "cloudformation"
+resource_type = "MULTIPLE"
+
 policy[p] {
   nacl = nacls[_]
   not nacl_library.nacl_ingress_zero_cidr_to_port(nacl.id, 3389)


### PR DESCRIPTION
This PR fixes a small issue I noticed while reviewing rules - `input_type` and `resource_type` are missing for these two.