### PR TITLE
[RM-5634] #126 Remove coloring for WAIVED status and severity

### DIFF
--- a/changes/unreleased/Fixed-20210602-141014.yaml
+++ b/changes/unreleased/Fixed-20210602-141014.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '#126 Remove coloring for WAIVED status and severity in table output so that
+  it''s readable against a black background.'

--- a/pkg/reporter/table.go
+++ b/pkg/reporter/table.go
@@ -114,7 +114,6 @@ func (r TableRow) toCell() []*simpletable.Cell {
 	}
 }
 
-var waivedColor func(...interface{}) string = color.New(color.FgBlack).SprintFunc()
 var failedColor func(...interface{}) string = color.New(color.FgRed).SprintFunc()
 var passedColor func(...interface{}) string = color.New(color.FgGreen).SprintFunc()
 var unknownColor func(...interface{}) string = color.New(color.FgMagenta).SprintFunc()
@@ -129,20 +128,14 @@ func colorizeResult(result string) string {
 		return passedColor(result)
 	case "FAIL":
 		return failedColor(result)
-	case "WAIVED":
-		return waivedColor(result)
 	default:
 		return result
 	}
 }
 
 func colorizeSeverity(r RuleResult) string {
-	if r.RuleResult == "PASS" {
+	if r.RuleResult == "PASS" || r.RuleResult == "WAIVED" {
 		return r.RuleSeverity
-	}
-
-	if r.RuleResult == "WAIVED" {
-		return waivedColor(r.RuleSeverity)
 	}
 
 	switch r.RuleSeverity {


### PR DESCRIPTION
This PR changes the table output so that `WAIVED` status and severity use the default foreground color. We were using black, which is difficult to read in dark color schemes.