### PR TITLE
[RM-5656] Accept _ in flag names, e.g. "--input_type=tf_plan"

### DIFF
--- a/cmd/normalize_flag.go
+++ b/cmd/normalize_flag.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+func normalizeFlag(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	name = strings.Replace(name, "_", "-", -1)
+	return pflag.NormalizedName(name)
+}

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -53,6 +53,7 @@ func NewREPLCommand() *cobra.Command {
 
 	cmd.Flags().BoolP("user-only", "u", false, "Disable built-in rules")
 	cmd.Flags().Bool("no-test-inputs", false, "Disable loading test inputs")
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -120,6 +120,7 @@ func NewRunCommand() *cobra.Command {
 		enumflag.New(&format, "format", reporter.FormatIds, enumflag.EnumCaseInsensitive),
 		"format", "f",
 		"Set the output format")
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -64,7 +64,7 @@ func NewShowCommand() *cobra.Command {
 		enumflag.New(&inputType, "input-type", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		"input-type", "t",
 		"Set the input type for the given paths")
-
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -51,6 +51,7 @@ func NewTestCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolP("trace", "t", false, "Enable trace output")
 	cmd.Flags().Bool("no-test-inputs", false, "Disable loading test inputs")
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }
 

--- a/cmd/write_test_inputs.go
+++ b/cmd/write_test_inputs.go
@@ -44,6 +44,7 @@ func NewWriteTestInputsCommand() *cobra.Command {
 		enumflag.New(&inputType, "input-type", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		"input-type", "t",
 		"Set the input type for the given paths")
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,9 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/hashicorp/terraform-provider-google v1.20.0 // indirect
 	github.com/open-policy-agent/opa v0.28.0
-	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.0
 	github.com/terraform-providers/terraform-provider-google v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -583,7 +583,6 @@ github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -809,7 +808,6 @@ github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjM
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/pkg/loader/base.go
+++ b/pkg/loader/base.go
@@ -47,7 +47,7 @@ const (
 // CLI options.
 var InputTypeIDs = map[InputType][]string{
 	Auto:   {"auto"},
-	TfPlan: {"tf-plan"},
+	TfPlan: {"tf-plan", "tf_plan"},
 	Cfn:    {"cfn"},
 	Tf:     {"tf"},
 }


### PR DESCRIPTION
This is a small PR to allow users to use `_` as the word-separator in the Regula CLI flags and flag values, for example `--input_type tf_plan` works the same as `--input-type tf-plan`. The `normalizeFlag` function normalizes `--input_type` -> `--input-type`. For our enum flag values (like the `--input-type` values) we'll need to add aliases to the name map for the type, like in the `pkg/loader/base.go` change.