### PR TITLE
[RM-5669] Rule compliance mapping and severity updates

### DIFF
--- a/rego/rules/tf/aws/cloudtrail/log_file_validation.rego
+++ b/rego/rules/tf/aws/cloudtrail/log_file_validation.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_2.2"
       ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_3.2"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_AC-2g",
         "NIST-800-53_vRev4_AC-6(9)"

--- a/rego/rules/tf/aws/ebs/volume_encrypted.rego
+++ b/rego/rules/tf/aws/ebs/volume_encrypted.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
   "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
   "custom": {
     "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.2.1"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_SC-13"
       ]

--- a/rego/rules/tf/aws/iam/admin_policy.rego
+++ b/rego/rules/tf/aws/iam/admin_policy.rego
@@ -23,6 +23,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_1.22"
+      ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_1.16"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/iam/user_attached_policy.rego
+++ b/rego/rules/tf/aws/iam/user_attached_policy.rego
@@ -24,6 +24,9 @@ __rego__metadoc__ := {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_1.16"
       ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_1.15"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_AC-2(7)(b)"
       ]

--- a/rego/rules/tf/aws/kms/key_rotation.rego
+++ b/rego/rules/tf/aws/kms/key_rotation.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_2.8"
+      ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_3.8"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/s3/bucket_sse.rego
+++ b/rego/rules/tf/aws/s3/bucket_sse.rego
@@ -20,6 +20,9 @@ __rego__metadoc__ := {
   "description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
   "custom": {
     "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.1.1"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_SC-13"
       ]

--- a/rego/rules/tf/aws/security_group/ingress_anywhere_rdp.rego
+++ b/rego/rules/tf/aws/security_group/ingress_anywhere_rdp.rego
@@ -24,11 +24,15 @@ __rego__metadoc__ := {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_4.2"
       ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_5.2"
+      ],
       "NIST": [
         "NIST-800-53_vRev4_AC-4",
         "NIST-800-53_vRev4_AC-17(3)"
       ]
-    }
+    },
+    "severity": "High"
   }
 }
 

--- a/rego/rules/tf/aws/security_group/ingress_anywhere_ssh.rego
+++ b/rego/rules/tf/aws/security_group/ingress_anywhere_ssh.rego
@@ -24,11 +24,15 @@ __rego__metadoc__ := {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_4.1"
       ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_5.2"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_AC-4",
         "NIST-800-53_vRev4_AC-17(3)"
       ]
-    }
+    },
+    "severity": "High"
   }
 }
 

--- a/rego/rules/tf/aws/vpc/flow_log.rego
+++ b/rego/rules/tf/aws/vpc/flow_log.rego
@@ -24,6 +24,9 @@ __rego__metadoc__ := {
       "CIS-AWS_v1.2.0": [
         "CIS-AWS_v1.2.0_2.9"
       ],
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_3.9"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_AC-4",
         "NIST-800-53_vRev4_AC-7a",

--- a/rego/rules/tf/azurerm/storage/account_deny_access.rego
+++ b/rego/rules/tf/azurerm/storage/account_deny_access.rego
@@ -22,7 +22,8 @@ __rego__metadoc__ := {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.7"
       ]
-    }
+    },
+    "severity": "High"
   }
 }
 

--- a/rego/rules/tf/azurerm/storage/account_microsoft_services.rego
+++ b/rego/rules/tf/azurerm/storage/account_microsoft_services.rego
@@ -22,7 +22,8 @@ __rego__metadoc__ := {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.8"
       ]
-    }
+    },
+    "severity": "Medium"
   }
 }
 

--- a/rego/rules/tf/azurerm/storage/container_private_access.rego
+++ b/rego/rules/tf/azurerm/storage/container_private_access.rego
@@ -22,7 +22,8 @@ __rego__metadoc__ := {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.6"
       ]
-    }
+    },
+    "severity": "Critical"
   }
 }
 

--- a/rego/rules/tf/google/compute/firewall_no_ingress_22.rego
+++ b/rego/rules/tf/google/compute/firewall_no_ingress_22.rego
@@ -20,15 +20,19 @@ package rules.tf_google_compute_firewall_no_ingress_22
 import data.fugue.gcp.compute_firewall
 
 __rego__metadoc__ := {
-  "id": "FG_R00379",
-  "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)",
-  "description": "VPC firewall rules should not permit unrestricted access from the internet to port 22 (SSH). Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.",
+  "id": "FG_R00407",
+  "title": "Network firewall rules should not permit ingress from 0.0.0.0/0 to port 22 (SSH)",
+  "description": "If SSH is open to the internet, attackers can attempt to gain access to VM instances. Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.",
   "custom": {
     "controls": {
       "CIS-Google_v1.0.0": [
         "CIS-Google_v1.0.0_3.6"
+      ],
+      "CIS-Google_v1.1.0": [
+        "CIS-Google_v1.1.0_3.6"
       ]
-    }
+    },
+    "severity": "High"
   }
 }
 

--- a/rego/rules/tf/google/compute/firewall_no_ingress_3389.rego
+++ b/rego/rules/tf/google/compute/firewall_no_ingress_3389.rego
@@ -20,15 +20,19 @@ package rules.tf_google_compute_firewall_no_ingress_3389
 import data.fugue.gcp.compute_firewall
 
 __rego__metadoc__ := {
-  "id": "FG_R00380",
-  "title": "VPC firewall rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)",
-  "description": "VPC firewall rules should not permit unrestricted access from the internet to port 3389 (RDP). Removing unfettered connectivity to remote console services, such as Remote Desktop Protocol, reduces a server's exposure to risk.",
+  "id": "FG_R00408",
+  "title": "Network firewall rules should not permit ingress from 0.0.0.0/0 to port 3389 (RDP)",
+  "description": "If RDP is open to the internet, attackers can attempt to gain access to VM instances. Removing unfettered connectivity to remote console services, such as RDP, reduces a server's exposure to risk.",
   "custom": {
     "controls": {
       "CIS-Google_v1.0.0": [
         "CIS-Google_v1.0.0_3.7"
+      ],
+      "CIS-Google_v1.1.0": [
+        "CIS-Google_v1.1.0_3.7"
       ]
-    }
+    },
+    "severity": "High"
   }
 }
 

--- a/rego/rules/tf/google/compute/subnet_flow_log_enabled.rego
+++ b/rego/rules/tf/google/compute/subnet_flow_log_enabled.rego
@@ -16,15 +16,19 @@
 package rules.tf_google_compute_subnet_flow_log_enabled
 
 __rego__metadoc__ := {
-  "id": "FG_R00381",
-  "title": "VPC subnet flow logging should be enabled",
-  "description": "Flow logs provide visibility into network traffic that traverses a VPC, and can be used to detect anomalous traffic and additional insights.",
+  "id": "FG_R00409",
+  "title": "Network subnet flow logs should be enabled",
+  "description": "It is recommended that flow logs be enabled for every business-critical VPC subnet, as they provide visibility into network traffic for each VM inside the subnet and can be used to detect anomalous traffic or insight during security workflows.",
   "custom": {
     "controls": {
       "CIS-Google_v1.0.0": [
         "CIS-Google_v1.0.0_3.9"
+      ],
+      "CIS-Google_v1.1.0": [
+        "CIS-Google_v1.1.0_3.8"
       ]
-    }
+    },
+    "severity": "Medium"
   }
 }
 

--- a/rego/rules/tf/google/compute/subnet_private_google_access.rego
+++ b/rego/rules/tf/google/compute/subnet_private_google_access.rego
@@ -26,7 +26,8 @@ __rego__metadoc__ := {
       "CIS-Google_v1.0.0": [
         "CIS-Google_v1.0.0_3.8"
       ]
-    }
+    },
+    "severity": "Low"
   }
 }
 

--- a/rego/rules/tf/google/kms/cryptokey_rotate.rego
+++ b/rego/rules/tf/google/kms/cryptokey_rotate.rego
@@ -17,14 +17,15 @@ package rules.tf_google_kms_cryptokey_rotate
 
 __rego__metadoc__ := {
   "id": "FG_R00378",
-  "title": "KMS crypto keys should be rotated at least once every 365 days",
-  "description": "Key rotation is a security best practice that helps reduce the potential impact of a compromised key, as users cannot use deprecated/older keys.",
+  "title": "KMS keys should be rotated every 90 days or less",
+  "description": "KMS keys should be rotated frequently because rotation helps reduce the potential impact of a compromised key as users cannot use the old key to access the data.",
   "custom": {
     "controls": {
-      "CIS-Google_v1.0.0": [
-        "CIS-Google_v1.0.0_1.8"
+      "CIS-Google_v1.1.0": [
+        "CIS-Google_v1.1.0_1.10"
       ]
-    }
+    },
+    "severity": "Medium"
   }
 }
 
@@ -37,5 +38,6 @@ allow {
   is_string(rotation_per)
   trimmed_rotation_per = trim_right(rotation_per, "s")
   num_rotation_per = to_number(trimmed_rotation_per)
-  num_rotation_per <= 31536000
+  # 90 days in seconds
+  num_rotation_per <= 7776000
 }

--- a/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra.json
+++ b/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra.json
@@ -16,7 +16,7 @@
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
             "rotation_period": null,
-            "skip_initial_version_creation": false,
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -31,8 +31,8 @@
             "labels": null,
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
-            "rotation_period": "31536002s",
-            "skip_initial_version_creation": false,
+            "rotation_period": "7776002s",
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -47,8 +47,8 @@
             "labels": null,
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
-            "rotation_period": "31536000s",
-            "skip_initial_version_creation": false,
+            "rotation_period": "7776000s",
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -85,7 +85,7 @@
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
           "rotation_period": null,
-          "skip_initial_version_creation": false,
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {
@@ -111,8 +111,8 @@
           "labels": null,
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
-          "rotation_period": "31536002s",
-          "skip_initial_version_creation": false,
+          "rotation_period": "7776002s",
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {
@@ -138,8 +138,8 @@
           "labels": null,
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
-          "rotation_period": "31536000s",
-          "skip_initial_version_creation": false,
+          "rotation_period": "7776000s",
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {
@@ -211,7 +211,7 @@
               "constant_value": "crypto-key-example"
             },
             "rotation_period": {
-              "constant_value": "31536002s"
+              "constant_value": "7776002s"
             }
           },
           "schema_version": 1
@@ -232,7 +232,7 @@
               "constant_value": "crypto-key-example"
             },
             "rotation_period": {
-              "constant_value": "31536000s"
+              "constant_value": "7776000s"
             }
           },
           "schema_version": 1

--- a/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra.tf
+++ b/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra.tf
@@ -19,7 +19,7 @@ resource "google_kms_key_ring" "keyring" {
 resource "google_kms_crypto_key" "valid_key_1" {
   name            = "crypto-key-example"
   key_ring        = "${google_kms_key_ring.keyring.self_link}"
-  rotation_period = "31536000s"
+  rotation_period = "7776000s"
 
   lifecycle {
     prevent_destroy = true
@@ -38,7 +38,7 @@ resource "google_kms_crypto_key" "invalid_key_1" {
 resource "google_kms_crypto_key" "invalid_key_2" {
   name            = "crypto-key-example"
   key_ring        = "${google_kms_key_ring.keyring.self_link}"
-  rotation_period = "31536002s"
+  rotation_period = "7776002s"
 
   lifecycle {
     prevent_destroy = true

--- a/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra_json.rego
+++ b/rego/tests/rules/tf/google/kms/inputs/cryptokey_rotate_infra_json.rego
@@ -53,7 +53,7 @@ mock_config := {
               "constant_value": "crypto-key-example"
             },
             "rotation_period": {
-              "constant_value": "31536002s"
+              "constant_value": "7776002s"
             }
           },
           "mode": "managed",
@@ -74,7 +74,7 @@ mock_config := {
               "constant_value": "crypto-key-example"
             },
             "rotation_period": {
-              "constant_value": "31536000s"
+              "constant_value": "7776000s"
             }
           },
           "mode": "managed",
@@ -118,7 +118,7 @@ mock_config := {
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
             "rotation_period": null,
-            "skip_initial_version_creation": false,
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -133,8 +133,8 @@ mock_config := {
             "labels": null,
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
-            "rotation_period": "31536002s",
-            "skip_initial_version_creation": false,
+            "rotation_period": "7776002s",
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -149,8 +149,8 @@ mock_config := {
             "labels": null,
             "name": "crypto-key-example",
             "purpose": "ENCRYPT_DECRYPT",
-            "rotation_period": "31536000s",
-            "skip_initial_version_creation": false,
+            "rotation_period": "7776000s",
+            "skip_initial_version_creation": null,
             "timeouts": null
           }
         },
@@ -182,7 +182,7 @@ mock_config := {
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
           "rotation_period": null,
-          "skip_initial_version_creation": false,
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {
@@ -208,8 +208,8 @@ mock_config := {
           "labels": null,
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
-          "rotation_period": "31536002s",
-          "skip_initial_version_creation": false,
+          "rotation_period": "7776002s",
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {
@@ -235,8 +235,8 @@ mock_config := {
           "labels": null,
           "name": "crypto-key-example",
           "purpose": "ENCRYPT_DECRYPT",
-          "rotation_period": "31536000s",
-          "skip_initial_version_creation": false,
+          "rotation_period": "7776000s",
+          "skip_initial_version_creation": null,
           "timeouts": null
         },
         "after_unknown": {


### PR DESCRIPTION
This PR makes a few changes to rule compliance mappings and metadata:
* Adds `severity` where it was missing
  * Note that we'll still have one rule without a severity: `rego/rules/tf/aws/security_group/ingress_anywhere.rego`
* Adds `CIS-AWS_v1.3.0` mappings to the terraform AWS rules.
* Updates the IDs and descriptions for a few Google rules where we had duplicates.
* Updates one of the Google rules for CIS-Google_v1.1.0: `rego/rules/tf/google/kms/cryptokey_rotate.rego`
  * The latest version of the spec enforces rotation every 90 days instead of every 365 days. I updated the tests to match.
