### PR TITLE
[RM-5678] Unify input type

### DIFF
--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -175,7 +175,6 @@ type RuleResult struct {
 	RuleResult      string   `json:"rule_result"`
 	RuleSeverity    string   `json:"rule_severity"`
 	RuleSummary     string   `json:"rule_summary"`
-	RuleInputType   string   `json:"rule_input_type"`
 }
 
 func (r RuleResult) IsWaived() bool {

--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -175,6 +175,7 @@ type RuleResult struct {
 	RuleResult      string   `json:"rule_result"`
 	RuleSeverity    string   `json:"rule_severity"`
 	RuleSummary     string   `json:"rule_summary"`
+	RuleInputType   string   `json:"rule_input_type"`
 }
 
 func (r RuleResult) IsWaived() bool {

--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -164,7 +164,7 @@ func (o RegulaOutput) AggregateByFilepath() ResultsByFilepath {
 type RuleResult struct {
 	Controls        []string `json:"controls"`
 	Filepath        string   `json:"filepath"`
-	Platform        string   `json:"platform"`
+	InputType       string   `json:"input_type"`
 	Provider        string   `json:"provider"`
 	ResourceID      string   `json:"resource_id"`
 	ResourceType    string   `json:"resource_type"`

--- a/rego/lib/fugue.rego
+++ b/rego/lib/fugue.rego
@@ -13,6 +13,8 @@
 # limitations under the License.
 package fugue
 
+import data.fugue.input_type_internal
+
 resource_types = {rt |
   r = input.resources[_]
   rt = r._type
@@ -96,3 +98,7 @@ report_v0(message, policy) = ret {
 
 # Provided for backward-compatibility with older Fugue rules only.
 resource_types_v0 = resource_types
+
+input_type() = ret {
+  ret := input_type_internal.input_type
+}

--- a/rego/lib/fugue.rego
+++ b/rego/lib/fugue.rego
@@ -96,11 +96,3 @@ report_v0(message, policy) = ret {
 
 # Provided for backward-compatibility with older Fugue rules only.
 resource_types_v0 = resource_types
-
-# Predicate to determine if we support the input type.
-# See the `input_type.rego` module for more.
-# This replaces the `engine` field in earlier versions.
-supported_input_type(input_type) {
-  supported := {"tf", "tf_plan", "cfn"}
-  supported[input_type]
-}

--- a/rego/lib/fugue.rego
+++ b/rego/lib/fugue.rego
@@ -99,6 +99,6 @@ report_v0(message, policy) = ret {
 # Provided for backward-compatibility with older Fugue rules only.
 resource_types_v0 = resource_types
 
-input_type() = ret {
+input_type = ret {
   ret := input_type_internal.input_type
 }

--- a/rego/lib/fugue.rego
+++ b/rego/lib/fugue.rego
@@ -97,8 +97,10 @@ report_v0(message, policy) = ret {
 # Provided for backward-compatibility with older Fugue rules only.
 resource_types_v0 = resource_types
 
-# Engine running the rule.  Will be one of:
-#
-#  -  "regula"
-#  -  "runtime"
-engine = "regula"
+# Predicate to determine if we support the input type.
+# See the `input_type.rego` module for more.
+# This replaces the `engine` field in earlier versions.
+supported_input_type(input_type) {
+  supported := {"tf", "tf_plan", "cfn"}
+  supported[input_type]
+}

--- a/rego/lib/fugue/input_type.rego
+++ b/rego/lib/fugue/input_type.rego
@@ -15,26 +15,40 @@
 # This module detects the input format based on fields set in it.
 package fugue.input_type
 
-input_type = "terraform" {
-  terraform_input_type
-} else = "cloudformation" {
-  cloudformation_input_type
+# These are the currently supported input types:
+#
+#  -  "tf"
+#  -  "tf_plan"
+#  -  "tf_runtime"
+#  -  "cfn"
+#
+# To check the current resource type, use `input_type`.
+# To check if this input type is supported, use `fugue.supported_input_type`.
+# To check if a rule applies for this input type, use
+# `compatibility`.
+
+input_type = "tf" {
+  _ = input.hcl_resource_view_version
+} else = "tf_plan" {
+  _ = input.terraform_version
+} else = "tf_plan" {
+  _ = input.resource_changes
+} else = "tf_plan" {
+  _ = input.planned_values
+} else = "cfn" {
+  _ = input.Resources
+} else = "cfn" {
+  _ = input.AWSTemplateFormatVersion
 }
 
 terraform_input_type {
-  _ = input.hcl_resource_view_version
+  input_type == "tf"
 } {
-  _ = input.terraform_version
-} {
-  _ = input.resource_changes
-} {
-  _ = input.planned_values
+  input_type == "tf_plan"
 }
 
 cloudformation_input_type {
-  _ = input.Resources
-} {
-  _ = input.AWSTemplateFormatVersion
+  input_type == "cfn"
 }
 
 rule_input_type(pkg) = ret {
@@ -44,5 +58,15 @@ rule_input_type(pkg) = ret {
   ret = data["rules"][pkg][k]
   k = "input_type"
 } else = ret {
-  ret = "terraform"
+  ret = "tf"
+}
+
+# Which rule input type is applicable for which input types?
+compatibility := {
+  "tf":             {"tf", "tf_plan", "tf_runtime"},
+  "terraform":      {"tf", "tf_plan", "tf_runtime"},  # Backwards-compatibility
+  "tf_plan":        {"tf_plan"},
+  "tf_runtime":     {"tf_runtime"},
+  "cfn":            {"cfn"},
+  "cloudformation": {"cfn"},  # Backwards-compatibility
 }

--- a/rego/lib/fugue/input_type.rego
+++ b/rego/lib/fugue/input_type.rego
@@ -23,9 +23,7 @@ package fugue.input_type
 #  -  "cfn"
 #
 # To check the current resource type, use `input_type`.
-# To check if this input type is supported, use `fugue.supported_input_type`.
-# To check if a rule applies for this input type, use
-# `compatibility`.
+# To check if a rule applies for this input type, use `compatibility`.
 
 input_type = "tf" {
   _ = input.hcl_resource_view_version

--- a/rego/lib/fugue/input_type.rego
+++ b/rego/lib/fugue/input_type.rego
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This module detects the input format based on fields set in it.
-package fugue.input_type
+package fugue.input_type_internal
 
 # These are the currently supported input types:
 #

--- a/rego/lib/fugue/regula.rego
+++ b/rego/lib/fugue/regula.rego
@@ -14,7 +14,7 @@
 package fugue.regula
 
 import data.fugue
-import data.fugue.input_type
+import data.fugue.input_type_internal
 import data.fugue.resource_view
 
 # Construct a judgement using results from a single- resource rule.
@@ -121,12 +121,12 @@ rule_resource_result(rule, judgement) = ret {
     "rule_message": judgement.message,
     "rule_result": result_string(judgement),
     "rule_name": rule["package"],
-    "platform": rule.input_type,  # TODO: Does the naming here still make sense?
     "rule_id": rule.metadata.id,
     "rule_summary": rule.metadata.summary,
     "rule_description": rule.metadata.description,
     "rule_severity": rule.metadata.severity,
     "controls": rule.metadata.controls,
+    "input_type": rule.input_type,
   }
 }
 
@@ -197,8 +197,8 @@ single_report := ret {
   # We filter down the applicable rules by input kind.
   rules = [rule |
     resource_type = data.rules[pkg].resource_type
-    rule_input_type = input_type.rule_input_type(pkg)
-    input_type.compatibility[rule_input_type][input_type.input_type]
+    rule_input_type = input_type_internal.rule_input_type(pkg)
+    input_type_internal.compatibility[rule_input_type][input_type_internal.input_type]
     rule = {
       "package": pkg,
       "input_type": rule_input_type,

--- a/rego/lib/fugue/regula.rego
+++ b/rego/lib/fugue/regula.rego
@@ -126,7 +126,8 @@ rule_resource_result(rule, judgement) = ret {
     "rule_description": rule.metadata.description,
     "rule_severity": rule.metadata.severity,
     "controls": rule.metadata.controls,
-    "input_type": rule.input_type,
+    "input_type": input_type_internal.input_type,
+    "rule_input_type": rule.input_type,
   }
 }
 

--- a/rego/lib/fugue/regula.rego
+++ b/rego/lib/fugue/regula.rego
@@ -121,7 +121,7 @@ rule_resource_result(rule, judgement) = ret {
     "rule_message": judgement.message,
     "rule_result": result_string(judgement),
     "rule_name": rule["package"],
-    "platform": rule.input_type,
+    "platform": rule.input_type,  # TODO: Does the naming here still make sense?
     "rule_id": rule.metadata.id,
     "rule_summary": rule.metadata.summary,
     "rule_description": rule.metadata.description,
@@ -198,7 +198,7 @@ single_report := ret {
   rules = [rule |
     resource_type = data.rules[pkg].resource_type
     rule_input_type = input_type.rule_input_type(pkg)
-    rule_input_type == input_type.input_type
+    input_type.compatibility[rule_input_type][input_type.input_type]
     rule = {
       "package": pkg,
       "input_type": rule_input_type,

--- a/rego/lib/fugue/regula.rego
+++ b/rego/lib/fugue/regula.rego
@@ -127,7 +127,6 @@ rule_resource_result(rule, judgement) = ret {
     "rule_severity": rule.metadata.severity,
     "controls": rule.metadata.controls,
     "input_type": input_type_internal.input_type,
-    "rule_input_type": rule.input_type,
   }
 }
 

--- a/rego/lib/fugue/regula_config.rego
+++ b/rego/lib/fugue/regula_config.rego
@@ -1,0 +1,19 @@
+# This package declares an empty set of rules and waivers to make sure user
+# configuration have to follow these types with incremental definitions.
+package fugue.regula.config
+
+waivers[waiver] {
+  waiver := {
+    "resource_id": "*",
+    "resource_type": "*",
+    "rule_id": "*",
+    "rule_name": "*",
+    "filepath": "*",
+  }
+  false
+}
+
+rules[rule] {
+  rule := {"rule_id": "*", "rule_name": "*", "status": "ENABLED"}
+  false
+}

--- a/rego/lib/fugue/resource_view.rego
+++ b/rego/lib/fugue/resource_view.rego
@@ -17,7 +17,7 @@
 # see `lib/fugue/resource_view/`.
 package fugue.resource_view
 
-import data.fugue.input_type
+import data.fugue.input_type_internal
 import data.fugue.resource_view.cloudformation
 import data.fugue.resource_view.terraform
 
@@ -26,10 +26,10 @@ resource_view = ret {
   _ = input.hcl_resource_view_version
   ret = input.resources
 } else = ret {
-  input_type.terraform_input_type
+  input_type_internal.terraform_input_type
   ret = terraform.resource_view
 } else = ret {
-  input_type.cloudformation_input_type
+  input_type_internal.cloudformation_input_type
   ret = cloudformation.resource_view
 }
 
@@ -37,9 +37,9 @@ resource_view_input = ret {
   _ = input.hcl_resource_view_version
   ret = {"resources": resource_view}
 } else = ret {
-  input_type.terraform_input_type
+  input_type_internal.terraform_input_type
   ret = {"resources": resource_view, "_plan": input}
 } else = ret {
-  input_type.cloudformation_input_type
+  input_type_internal.cloudformation_input_type
   ret = {"resources": resource_view, "_template": input}
 }

--- a/rego/rules/cfn/api_gateway/classic_custom_domain_name.rego
+++ b/rego/rules/cfn/api_gateway/classic_custom_domain_name.rego
@@ -24,7 +24,7 @@ __rego__metadoc__ := {
   "title": "API Gateway classic custom domains should use secure TLS protocol versions (1.2 and above)"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 domain_names = fugue.resources("AWS::ApiGateway::DomainName")

--- a/rego/rules/cfn/api_gateway/v2_custom_domain_name.rego
+++ b/rego/rules/cfn/api_gateway/v2_custom_domain_name.rego
@@ -24,7 +24,7 @@ __rego__metadoc__ := {
   "title": "API Gateway v2 custom domains should use secure TLS protocol versions (1.2 and above) "
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 domain_names = fugue.resources("AWS::ApiGatewayV2::DomainName")

--- a/rego/rules/cfn/cloudtrail/cloudwatch.rego
+++ b/rego/rules/cfn/cloudtrail/cloudwatch.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "CloudTrail trails should have CloudWatch log integration enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::CloudTrail::Trail"
 
 default allow = false

--- a/rego/rules/cfn/cloudtrail/encryption.rego
+++ b/rego/rules/cfn/cloudtrail/encryption.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "CloudTrail log files should be encrypted using KMS CMKs"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::CloudTrail::Trail"
 
 default allow = false

--- a/rego/rules/cfn/cloudtrail/log_validation.rego
+++ b/rego/rules/cfn/cloudtrail/log_validation.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "CloudTrail log file validation should be enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::CloudTrail::Trail"
 
 default allow = false

--- a/rego/rules/cfn/cloudtrail/s3_access_logging.rego
+++ b/rego/rules/cfn/cloudtrail/s3_access_logging.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket access logging should be enabled on S3 buckets that store CloudTrail log files"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 cloudtrails = fugue.resources("AWS::CloudTrail::Trail")

--- a/rego/rules/cfn/cloudtrail/target.rego
+++ b/rego/rules/cfn/cloudtrail/target.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket ACLs should not have public access on S3 buckets that store CloudTrail log files"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 cloudtrails := fugue.resources("AWS::CloudTrail::Trail")
 buckets := fugue.resources("AWS::S3::Bucket")
 

--- a/rego/rules/cfn/ebs/volume_encryption.rego
+++ b/rego/rules/cfn/ebs/volume_encryption.rego
@@ -27,7 +27,7 @@ __rego__metadoc__ := {
   "title": "EBS volume encryption should be enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::EC2::Volume"
 
 default allow = false

--- a/rego/rules/cfn/iam/admin_policy.rego
+++ b/rego/rules/cfn/iam/admin_policy.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
 }
 
 resource_type := "MULTIPLE"
-input_type := "cloudformation"
+input_type := "cfn"
 
 policy_resources[resource_id] = ret {
   iam_policy := fugue.resources("AWS::IAM::Policy")[resource_id]

--- a/rego/rules/cfn/iam/policy.rego
+++ b/rego/rules/cfn/iam/policy.rego
@@ -32,7 +32,7 @@ __rego__metadoc__ := {
   "title": "IAM policies should not be attached to users"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "MULTIPLE"
 
 iam_policies := fugue.resources("AWS::IAM::Policy")

--- a/rego/rules/cfn/kms/key_rotation.rego
+++ b/rego/rules/cfn/kms/key_rotation.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "KMS CMK rotation should be enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::KMS::Key"
 
 default allow = false

--- a/rego/rules/cfn/lambda/function_not_public.rego
+++ b/rego/rules/cfn/lambda/function_not_public.rego
@@ -25,7 +25,7 @@ __rego__metadoc__ := {
   "title": "Lambda function policies should not allow global access"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 permissions = fugue.resources("AWS::Lambda::Permission")

--- a/rego/rules/cfn/s3/block_public_access.rego
+++ b/rego/rules/cfn/s3/block_public_access.rego
@@ -27,7 +27,7 @@ __rego__metadoc__ := {
   "title": "S3 buckets should have all `block public access` options enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::S3::Bucket"
 
 default allow = false

--- a/rego/rules/cfn/s3/cloudtrail_s3_data_logging_read.rego
+++ b/rego/rules/cfn/s3/cloudtrail_s3_data_logging_read.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket object-level logging for read events should be enabled"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 trails = fugue.resources("AWS::CloudTrail::Trail")

--- a/rego/rules/cfn/s3/cloudtrail_s3_data_logging_write.rego
+++ b/rego/rules/cfn/s3/cloudtrail_s3_data_logging_write.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket object-level logging for write events should be enabled"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 trails = fugue.resources("AWS::CloudTrail::Trail")

--- a/rego/rules/cfn/s3/encryption.rego
+++ b/rego/rules/cfn/s3/encryption.rego
@@ -27,7 +27,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket server side encryption should be enabled"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "AWS::S3::Bucket"
 
 default allow = false

--- a/rego/rules/cfn/s3/https_access.rego
+++ b/rego/rules/cfn/s3/https_access.rego
@@ -30,7 +30,7 @@ __rego__metadoc__ := {
   "title": "S3 bucket policies should only allow requests that use HTTPS"
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 resource_type := "MULTIPLE"
 
 buckets := fugue.resources("AWS::S3::Bucket")

--- a/rego/rules/cfn/vpc/default_security_group.rego
+++ b/rego/rules/cfn/vpc/default_security_group.rego
@@ -32,7 +32,7 @@ __rego__metadoc__ := {
   "title": "VPC default security group should restrict all traffic"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 ingress_rules = fugue.resources("AWS::EC2::SecurityGroupIngress")

--- a/rego/rules/cfn/vpc/flow_logging_enabled.rego
+++ b/rego/rules/cfn/vpc/flow_logging_enabled.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
 }
 
 resource_type = "MULTIPLE"
-input_type = "cloudformation"
+input_type = "cfn"
 
 vpcs = fugue.resources("AWS::EC2::VPC")
 flow_logs = fugue.resources("AWS::EC2::FlowLog")

--- a/rego/rules/cfn/vpc/ingress_22.rego
+++ b/rego/rules/cfn/vpc/ingress_22.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
   "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH)"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 policy[p] {

--- a/rego/rules/cfn/vpc/ingress_3389.rego
+++ b/rego/rules/cfn/vpc/ingress_3389.rego
@@ -33,7 +33,7 @@ __rego__metadoc__ := {
   "title": "VPC security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)"
 }
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 policy[p] {

--- a/rego/rules/cfn/vpc/nacl_ingress_22.rego
+++ b/rego/rules/cfn/vpc/nacl_ingress_22.rego
@@ -32,7 +32,7 @@ __rego__metadoc__ := {
 
 nacls = fugue.resources("AWS::EC2::NetworkAcl")
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 policy[p] {

--- a/rego/rules/cfn/vpc/nacl_ingress_3389.rego
+++ b/rego/rules/cfn/vpc/nacl_ingress_3389.rego
@@ -32,7 +32,7 @@ __rego__metadoc__ := {
 
 nacls = fugue.resources("AWS::EC2::NetworkAcl")
 
-input_type = "cloudformation"
+input_type = "cfn"
 resource_type = "MULTIPLE"
 
 policy[p] {

--- a/rego/tests/lib/fugue_regula_report_02_test.rego
+++ b/rego/tests/lib/fugue_regula_report_02_test.rego
@@ -33,12 +33,12 @@ mock_input := [
 mock_rules := {
   "deny_cloudtrails": {
     "resource_type": "AWS::CloudTrail::Trail",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "allow": false
   },
   "allow_buckets": {
     "resource_type": "AWS::S3::Bucket",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "deny": false
   }
 }

--- a/rego/tests/lib/fugue_regula_report_03_test.rego
+++ b/rego/tests/lib/fugue_regula_report_03_test.rego
@@ -33,18 +33,18 @@ mock_input := [
 mock_rules := {
   "deny_cloudtrails": {
     "resource_type": "AWS::CloudTrail::Trail",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "allow": false
   },
   "deny_buckets": {
     "__rego__metadoc__": {"id": "TEST_123"},
     "resource_type": "AWS::S3::Bucket",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "allow": false
   },
   "allow_buckets": {
     "resource_type": "AWS::S3::Bucket",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "deny": false
   }
 }

--- a/rego/tests/lib/fugue_regula_report_04_test.rego
+++ b/rego/tests/lib/fugue_regula_report_04_test.rego
@@ -33,18 +33,18 @@ mock_input := [
 mock_rules := {
   "deny_cloudtrails": {
     "resource_type": "AWS::CloudTrail::Trail",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "allow": false
   },
   "deny_buckets": {
     "__rego__metadoc__": {"id": "TEST_123"},
     "resource_type": "AWS::S3::Bucket",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "allow": false
   },
   "allow_buckets": {
     "resource_type": "AWS::S3::Bucket",
-    "input_type": "cloudformation",
+    "input_type": "cfn",
     "deny": false
   }
 }


### PR DESCRIPTION
This PR removes `fugue.engine` and replaces it by `input_type` more consistently.  There are 3 input types that are relevant for Regula:

- `tf` (general tf rules)
- `tf_plan` (tf rules that need plan info)
- `cfn` (cloudformation rules)

Some of these are compatible with each other, and Regula tries to be smart about this (including supporting the older `input_type = "cloudformation"`) in rules.