### PR TITLE
[RM-5686] Fix bug when reading HCL from stdin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/terraform-provider-google v1.20.0 // indirect
 	github.com/open-policy-agent/opa v0.28.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
This PR fixes a panic when reading HCL from stdin. The way this fix works is that when an input is stdin, we'll use Afero's `MemMapFs` (instead of the default `OsFs` that we get from passing `nil` to `NewParser()`) and make an in-memory file with stdin's contents.

### Example outputs

Just reading stdin

```shell
./bin/regula run < ./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf  

{
  "rule_results": [
    {
      "controls": [
        "CIS-AWS_v1.2.0_2.8",
        "CIS-AWS_v1.3.0_3.8"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_kms_key.key",
      "resource_type": "aws_kms_key",
      "rule_description": "KMS CMK rotation should be enabled. It is recommended that users enable rotation for the customer created AWS Customer Master Key (CMK). Rotating encryption keys helps reduce the potential impact of a compromised key as users cannot use the old key to access the data.",
      "rule_id": "FG_R00036",
      "rule_message": "KMS key rotation should be enabled",
      "rule_name": "tf_aws_kms_key_rotation",
      "rule_result": "FAIL",
      "rule_severity": "Medium",
      "rule_summary": "KMS CMK rotation should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.aes_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.kms_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.unencrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "FAIL",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    }
  ],
  "summary": {
    "filepaths": [
      "<stdin>"
    ],
    "rule_results": {
      "FAIL": 2,
      "PASS": 2,
      "WAIVED": 0
    },
    "severities": {
      "Critical": 0,
      "High": 1,
      "Informational": 0,
      "Low": 0,
      "Medium": 1,
      "Unknown": 0
    }
  }
}
```

Reading from stdin and a file in the same command

```shell
./bin/regula run - ./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf < ./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf

{
  "rule_results": [
    {
      "controls": [
        "CIS-AWS_v1.2.0_2.8",
        "CIS-AWS_v1.3.0_3.8"
      ],
      "filepath": "./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_kms_key.key",
      "resource_type": "aws_kms_key",
      "rule_description": "KMS CMK rotation should be enabled. It is recommended that users enable rotation for the customer created AWS Customer Master Key (CMK). Rotating encryption keys helps reduce the potential impact of a compromised key as users cannot use the old key to access the data.",
      "rule_id": "FG_R00036",
      "rule_message": "KMS key rotation should be enabled",
      "rule_name": "tf_aws_kms_key_rotation",
      "rule_result": "FAIL",
      "rule_severity": "Medium",
      "rule_summary": "KMS CMK rotation should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.kms_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.unencrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "FAIL",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.aes_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.2.0_2.8",
        "CIS-AWS_v1.3.0_3.8"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_kms_key.key",
      "resource_type": "aws_kms_key",
      "rule_description": "KMS CMK rotation should be enabled. It is recommended that users enable rotation for the customer created AWS Customer Master Key (CMK). Rotating encryption keys helps reduce the potential impact of a compromised key as users cannot use the old key to access the data.",
      "rule_id": "FG_R00036",
      "rule_message": "KMS key rotation should be enabled",
      "rule_name": "tf_aws_kms_key_rotation",
      "rule_result": "FAIL",
      "rule_severity": "Medium",
      "rule_summary": "KMS CMK rotation should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.aes_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.kms_encrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "PASS",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    },
    {
      "controls": [
        "CIS-AWS_v1.3.0_2.1.1",
        "NIST-800-53_vRev4_SC-13"
      ],
      "filepath": "<stdin>",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_s3_bucket.unencrypted",
      "resource_type": "aws_s3_bucket",
      "rule_description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
      "rule_id": "FG_R00099",
      "rule_message": "",
      "rule_name": "tf_aws_s3_bucket_sse",
      "rule_result": "FAIL",
      "rule_severity": "High",
      "rule_summary": "S3 bucket server side encryption should be enabled"
    }
  ],
  "summary": {
    "filepaths": [
      "./rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.tf",
      "<stdin>"
    ],
    "rule_results": {
      "FAIL": 4,
      "PASS": 4,
      "WAIVED": 0
    },
    "severities": {
      "Critical": 0,
      "High": 2,
      "Informational": 0,
      "Low": 0,
      "Medium": 2,
      "Unknown": 0
    }
  }
}
```