### PR TITLE
Change arg type names in help text to string

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -109,15 +109,15 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolP("user-only", "u", false, "Disable built-in rules")
 	cmd.Flags().BoolP("no-ignore", "n", false, "Disable use of .gitignore")
 	cmd.Flags().VarP(
-		enumflag.New(&inputType, "input-type", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
+		enumflag.New(&inputType, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		"input-type", "t",
 		"Set the input type for the given paths")
 	cmd.Flags().VarP(
-		enumflag.New(&severity, "severity", reporter.SeverityIds, enumflag.EnumCaseInsensitive),
+		enumflag.New(&severity, "string", reporter.SeverityIds, enumflag.EnumCaseInsensitive),
 		"severity", "s",
 		"Set the minimum severity that will result in a non-zero exit code.")
 	cmd.Flags().VarP(
-		enumflag.New(&format, "format", reporter.FormatIds, enumflag.EnumCaseInsensitive),
+		enumflag.New(&format, "string", reporter.FormatIds, enumflag.EnumCaseInsensitive),
 		"format", "f",
 		"Set the output format")
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -61,7 +61,7 @@ func NewShowCommand() *cobra.Command {
 	}
 
 	cmd.Flags().VarP(
-		enumflag.New(&inputType, "input-type", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
+		enumflag.New(&inputType, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		"input-type", "t",
 		"Set the input type for the given paths")
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)

--- a/cmd/write_test_inputs.go
+++ b/cmd/write_test_inputs.go
@@ -41,7 +41,7 @@ func NewWriteTestInputsCommand() *cobra.Command {
 	}
 
 	cmd.Flags().VarP(
-		enumflag.New(&inputType, "input-type", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
+		enumflag.New(&inputType, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		"input-type", "t",
 		"Set the input type for the given paths")
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)


### PR DESCRIPTION
Change the type names for all the enum flags to `string` so that they're consistent with other args.