### PR TITLE
[RM-5678] Add "unknown" result for input_type

### DIFF
--- a/rego/lib/fugue/input_type.rego
+++ b/rego/lib/fugue/input_type.rego
@@ -37,6 +37,8 @@ input_type = "tf" {
   _ = input.Resources
 } else = "cfn" {
   _ = input.AWSTemplateFormatVersion
+} else = "unknown" {
+  true
 }
 
 terraform_input_type {


### PR DESCRIPTION
This PR adds an "unknown" result for `fugue.input_type`. This guarantees that `fugue.input_type` will be defined when `input` is empty or undefined.