### PR TITLE
Include data. in data resource type names

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -320,6 +320,14 @@ func (c *HclConfiguration) renderResources() map[string]interface{} {
 	return resources
 }
 
+func renderResourceType(r *configs.Resource) string {
+	if r.Mode == addrs.DataResourceMode {
+		return "data." + r.Type
+	}
+
+	return r.Type
+}
+
 func (c *HclConfiguration) renderResource(
 	resourceId string, resource *configs.Resource,
 ) interface{} {
@@ -336,7 +344,7 @@ func (c *HclConfiguration) renderResource(
 	}
 
 	properties := make(map[string]interface{})
-	properties["_type"] = resource.Type
+	properties["_type"] = renderResourceType(resource)
 	properties["id"] = resourceId
 
 	body, ok := resource.Config.(*hclsyntax.Body)

--- a/rego/lib/fugue/resource_view/terraform.rego
+++ b/rego/lib/fugue/resource_view/terraform.rego
@@ -95,6 +95,13 @@ resource_values(resource) = ret {
   ret = {}
 }
 
+render_resource_type(resource) = ret {
+  resource.mode == "data"
+  ret = concat(".", [resource.mode, resource.type])
+} else = ret {
+  ret = resource.type
+}
+
 # Grab resources from planned values.  Add "id" and "_type" keys.
 planned_values_resources = {id: ret |
   planned_values_module_resources[_] = resource_section
@@ -104,7 +111,7 @@ planned_values_resources = {id: ret |
   provider = split_provider[count(split_provider)-1]
   ret = json.patch(resource_values(resource), [
     {"op": "add", "path": ["id"], "value": id},
-    {"op": "add", "path": ["_type"], "value": resource.type},
+    {"op": "add", "path": ["_type"], "value": render_resource_type(resource)},
     {"op": "add", "path": ["_provider"], "value": provider},
   ])
 }

--- a/rego/tests/lib/fugue_resource_view_01_test.rego
+++ b/rego/tests/lib/fugue_resource_view_01_test.rego
@@ -64,7 +64,7 @@ test_resource_view_01 {
       "source_json": null,
       "version": null,
       "policy_id": null,
-      "_type": "aws_iam_policy_document",
+      "_type": "data.aws_iam_policy_document",
       "_provider": "aws",
     }
   }

--- a/rego/tests/lib/fugue_resource_view_02_test.rego
+++ b/rego/tests/lib/fugue_resource_view_02_test.rego
@@ -37,7 +37,7 @@ test_resource_view_02 {
     },
     "data.aws_iam_policy_document.example": {
       "_provider": "aws",
-      "_type": "aws_iam_policy_document",
+      "_type": "data.aws_iam_policy_document",
       "id": "data.aws_iam_policy_document.example",
       "override_json": null,
       "override_policy_documents": null,


### PR DESCRIPTION
This PR changes the way we calculate `_type` for data resources. I was testing with a configuration that has a few [S3 bucket data resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) and realized that we don't distinguish between those and managed S3 bucket resources. After this change, data resources will be prefixed with `data.`, like `data.aws_s3_bucket`. This is a potentially breaking change, so it's worth some discussion.