### PR TITLE
Add rules page to docs site

### DIFF
--- a/docs/src/rules.md
+++ b/docs/src/rules.md
@@ -1,0 +1,3 @@
+# Rules List
+
+To view the full list of Regula rules, see our [GitHub repo](https://github.com/fugue/regula/tree/master/rego/rules).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Home: "index.md"
   - "getting-started.md"
   - "usage.md"
+  - "rules.md"
   - "report.md"
   - "configuration.md"
   - Integrations:


### PR DESCRIPTION
This PR adds a Rules List page to the docs site. It temporarily links to the rules directory in the regula repo and will be updated in a forthcoming PR to list all of the rules.