### PR TITLE
Update docs for 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,17 @@ Usage:
   regula [command]
 
 Available Commands:
-  help        Help about any command
-  repl        Start an interactive session for testing rules with Regula
-  run         Evaluate rules against infrastructure-as-code with Regula.
-  show        Show debug information.
-  test        Run OPA test with Regula.
+  help              Help about any command
+  repl              Start an interactive session for testing rules with Regula
+  run               Evaluate rules against infrastructure as code with Regula.
+  show              Show debug information.
+  test              Run OPA test with Regula.
+  version           Print version information.
+  write-test-inputs Persist dynamically-generated test inputs for use with other Rego interpreters
 
 Flags:
   -h, --help      help for regula
-  -v, --version   version for regula
+  -v, --verbose   verbose output
 
 Use "regula [command] --help" for more information about a command.
 ```
@@ -110,7 +112,7 @@ Visit [regula.dev](https://regula.dev) for more information about Regula, includ
 
 - [Regula's report output](https://regula.dev/report.html)
 - [Integrations](https://regula.dev/integrations/conftest.html)
-- [Writing](https://regula.dev/development/writing-rules.html) and [testing](https://regula.dev/development/rule-development.html) custom rules
+- [Writing](https://regula.dev/development/writing-rules.html) and [testing](https://regula.dev/development/testing-rules.html) custom rules
 - [Configuring waivers and disabling rules](https://regula.dev/configuration.html)
 - and more!
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -31,7 +31,7 @@ If an attribute is not specified for a waiver, Regula assumes a `*` value. Note 
 
 To add a waiver, add a waiver object to the `waivers` set in `fugue.regula.config`:
 
-```rego
+```ruby
 package fugue.regula.config
 
 waivers[waiver] {
@@ -46,7 +46,7 @@ The above example waives a single resource for a single rule.
 
 It is also possible to waive this rule for all resources:
 
-```rego
+```ruby
 package fugue.regula.config
 
 waivers[waiver] {
@@ -60,7 +60,7 @@ In this example, because `resource_id` is omitted, its default value `*` is assu
 
 You can configure multiple waivers by adding to the `waivers` set in `fugue.regula.config`:
 
-```rego
+```ruby
 package fugue.regula.config
 
 waivers[waiver] {
@@ -85,7 +85,7 @@ You can disable rules by `rule_name` (rule package name, omitting the `rules.` s
 
 Here's an example using `rule_id`:
 
-```rego
+```ruby
 package fugue.regula.config
 
 rules[rule] {
@@ -101,7 +101,7 @@ Below is an example using `rule_name`. Note that the `rules.` segment of the pac
 !!! tip
     You can find the `rule_name` by running Regula first and looking for `rule_name` in the report.
 
-```rego
+```ruby
 package fugue.regula.config
 
 rules[rule] {
@@ -114,7 +114,7 @@ rules[rule] {
 
 You can disable multiple rules by adding to the `rules` set in `fugue.regula.config`:
 
-```rego
+```ruby
 package fugue.regula.config
 
 rules[rule] {

--- a/docs/src/development/test-inputs.md
+++ b/docs/src/development/test-inputs.md
@@ -1,28 +1,20 @@
-# Rule Development
-
-Custom rule development generally has three parts:
-
-- Writing the IaC to be used as [test input](#test-inputs)
-- Writing the rule (as documented in [Writing Rules](writing-rules.md))
-- Writing the [rule tests](#writing-tests)
+# Test Inputs
 
 Understanding how Regula handles inputs is key to developing your own rules, since the test input can be used to help you write the rule and the rule tests.
 
-## Test inputs
-
 When Regula reads in an IaC file, it transforms the IaC into three types of JSON-formatted inputs:
 
-- `mock_config` -- the raw JSON representation fed into OPA.
-- `mock_input` -- a transformed representation of the `mock_config` that is used as input for [advanced rules](writing-rules.md#advanced-rules). This is known as the **resource view**.
-- `mock_resources` -- an alias for `mock_input.resources`, which is used as input for [simple rules](writing-rules.md#simple-rules).
+- `mock_resources` -- **Used as input for [simple rules](writing-rules.md#simple-rules)**. It's an alias for `mock_input.resources`.
+- `mock_input` -- **Used as input for [advanced rules](writing-rules.md#advanced-rules)**. It's a transformed representation of the `mock_config` known as the *resource view*.
+- `mock_config` -- the raw JSON representation fed into OPA. Used as input when checking configuration outside of resources, such as provider config.
 
 Regula dynamically generates each type of input at runtime when the IaC file is loaded, so you don't need to run a script to generate it. You can simply:
 
-- Load the files into [`regula repl`](../usage.md#repl) to [view the test input](#viewing-test-inputs) and help you [write a rule](writing-rules.md) or [write a test](#writing-tests)
-- Load the files into [`regula repl`](../usage.md#repl) to [interactively evaluate tests](#test-a-rule-via-regula-repl)
-- Load the files into [`regula test`](../usage.md#test) to [run the tests](#test-a-rule-via-regula-test)
+- Load the files into [`regula repl`](../usage.md#repl) to [view the test input](#viewing-test-inputs) and help you [write a rule](writing-rules.md) or [write a test](writing-tests.md)
+- Load the files into [`regula repl`](../usage.md#repl) to [interactively evaluate tests](testing-rules.md#test-a-rule-via-regula-repl)
+- Load the files into [`regula test`](../usage.md#test) to [run the tests](testing-rules.md#test-a-rule-via-regula-test)
 
-### A note about test input
+## A note about test input package names
 
 The package name for the test input is based on its path, relative to where you'll be running [`regula repl`](../usage.md#repl) or [`regula test`](../usage.md#test). Regula automatically generates the package name, replacing path separators with `.` and other characters (such as dashes) with `_`
 
@@ -73,7 +65,7 @@ test_my_advanced_rule {
 }
 ```
 
-### Viewing test inputs
+## Viewing test inputs
 
 You can easily view each type of test input for an IaC file by following the steps below:
 
@@ -81,7 +73,7 @@ You can easily view each type of test input for an IaC file by following the ste
 
         regula repl infra
 
-2. Enter the package name of the input type you want to view, following this pattern (as explained [above](#a-note-about-test-input)):
+2. Enter the package name of the input type you want to view, following this pattern (as explained [above](#a-note-about-test-input-package-names)):
 
         data.<path.to.file>.<iac filename without extension>_<extension>.<input type>
         
@@ -279,130 +271,3 @@ Here's how all three input types look for an example CloudFormation file:
       }
     }
     ```
-
-## Writing tests
-
-Consult [OPA's documentation](https://www.openpolicyagent.org/docs/latest/policy-testing/) for information on writing test rules, whose names must begin with `test_` (e.g., `test_my_rule`).
-
-In the Rego file containing the tests, you'll need to import the test input. Follow the pattern below to specify the package (as explained in [this note](#a-note-about-test-input)):
-
-```
-import data.<path.to.file>.<iac filename without extension>_<extension>
-```
-
-For instance:
-
-```
-import data.infra.cfn_resources_yaml
-```
-
-The path to the file should be relative to where you'll be running [`regula repl`](../usage.md#repl) or [`regula test`](../usage.md#test).
-
-In the `test_` rule, set the input to `mock_resources` for [simple rules](writing-rules.md#simple-rules) and `mock_input` for [advanced rules](writing-rules.md#advanced-rules).
-
-For instance, suppose you're writing a simple rule, and your IaC file is located at `infra/cfn_resources.yaml`. You'd import `data.infra.cfn_resources_yaml`, which you can then reference in a `test_` with `cfn_resources_yaml.mock_resources`. 
-
-The contents of the Rego test file `my_test.rego` might look like this:
-
-```
-package tests.my_test
-
-import data.rules.my_rule
-import data.infra.cfn_resources_yaml
-
-test_valid_my_rule {
-  my_rule.allow with input as cfn_resources_yaml.mock_resources["ValidResourceIDHere"]
-}
-
-test_invalid_my_rule {
-  not my_rule.allow with input as cfn_resources_yaml.mock_resources["InvalidResourceIDHere"]
-}
-```
-
-Likewise, suppose you're writing an advanced rule, and your IaC file is located at `infra/my_resources.tf`. You'd import `data.infra.my_resources_tf`, which you can then reference in a `test_` with `my_resources_tf.mock_input`. 
-
-The contents of the Rego test file `my_advanced_test.rego` might look like this:
-
-```
-package tests.my_advanced_test
-
-import data.rules.my_advanced_rule
-import data.infra.my_resources_tf
-
-test_my_rule {
-  pol = policy with input as my_resources_tf.mock_input
-  by_resource_id = {p.id: p.valid | pol[p]}
-  by_resource_id["ValidResourceIDHere"] == true
-  by_resource_id["InvalidResourceIDHere"] == false
-}
-```
-
-## Testing rules
-
-You can run rule tests using [`regula test`](../usage.md#test) or evaluate them interactively using [`regula repl`](../usage.md#repl). For each rule to be tested, you'll need three files:
-
-- The test Terraform or CloudFormation IaC file (aka test input)
-- The Rego rule file
-- The Rego tests file, where each test is prepended with `test_`
-
-In both cases, note the path to the IaC file relative to where you invoke `regula test` or `regula run` should align with the package name imported into the Rego test file, as explained in [this note](#a-note-about-test-input).
-
-#### Test a rule via `regula test`
-
-To test one or more rules via [`regula test`](../usage.md#test):
-
-```
-regula test path/to/rule path/to/tests path/to/IaC
-```
-
-- Example:
-
-        regula test rules/my_rule.rego tests/my_rule_test.rego infra/my_infra.tf
-
-- Example:
-
-        regula test .
-
-You'll see output like this:
-
-```
-PASS: 142/142
-```
-
-#### Test a rule via `regula repl`
-
-To test interactively test one or more rules via [`regula repl`](../usage.md#repl):
-
-1. Load the tests, rule, and IaC files into the REPL:
-
-        regula repl path/to/rule path/to/tests path/to/IaC
-
-    Example:
-    
-        regula repl rules/my_rule.rego tests/my_rule_test.rego infra/my_infra.tf
-        
-    Example:
-    
-        regula repl .
-
-2. Open the rule package:
-
-        package rules.my_rule
-
-3. Import the IaC package:
-
-        import data.infra.my_infra_tf
-
-4. Evaluate a test from your rule tests file:
-
-        data.rules.my_rule.allow with input as my_infra_tf.mock_resources["aws_s3_bucket.my_valid_bucket"]
-
-You'll see the result of the evaluation:
-
-```
-true
-```
-
-## Example rules
-
-You can view the [Regula library of rules](https://github.com/fugue/regula/tree/master/rego/rules) and accompanying [tests](https://github.com/fugue/regula/tree/master/rego/tests/rules) for reference. You'll also find some [example rules](https://github.com/fugue/regula/tree/master/rego/examples/aws) in the repo.

--- a/docs/src/development/test-inputs.md
+++ b/docs/src/development/test-inputs.md
@@ -49,7 +49,7 @@ import data.infra.cfn_resources_yaml
 
 When referenced in a `test_` for a simple rule, refer to the `mock_resources`:
 
-```
+```ruby
 test_valid_my_simple_rule {
   my_rule.allow with input as cfn_resources_yaml.mock_resources["ValidResourceIDHere"]
 }
@@ -57,7 +57,7 @@ test_valid_my_simple_rule {
 
 When referenced in a `test_` for an advanced rule, refer to the `mock_input`:
 
-```
+```ruby
 test_my_advanced_rule {
   pol = policy with input as cfn_resources_yaml.mock_input
   by_resource_id = {p.id: p.valid | pol[p]}
@@ -87,7 +87,7 @@ Here's how all three input types look for an example CloudFormation file:
 
 === "cfn_resources.yaml"
 
-    ```
+    ```yaml
     AWSTemplateFormatVersion: '2010-09-09'
     Resources:
       ValidManagedPolicy01:
@@ -115,7 +115,7 @@ Here's how all three input types look for an example CloudFormation file:
 
 === "mock_config"
 
-    ```
+    ```json
     {
       "AWSTemplateFormatVersion": "2010-09-09",
       "Resources": {
@@ -157,7 +157,7 @@ Here's how all three input types look for an example CloudFormation file:
 
 === "mock_input"
 
-    ```
+    ```json
     {
       "_template": {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -235,7 +235,7 @@ Here's how all three input types look for an example CloudFormation file:
 
 === "mock_resources"
 
-    ```
+    ```json
     {
       "InvalidManagedPolicy01": {
         "Description": "too short",

--- a/docs/src/development/testing-rules.md
+++ b/docs/src/development/testing-rules.md
@@ -1,0 +1,65 @@
+# Testing Rules
+
+You can run rule tests using [`regula test`](../usage.md#test) or evaluate them interactively using [`regula repl`](../usage.md#repl). For each rule to be tested, you'll need three files:
+
+- The test Terraform or CloudFormation IaC file (aka test input)
+- The Rego rule file
+- The Rego tests file, where each test is prepended with `test_`
+
+In both cases, note the path to the IaC file relative to where you invoke `regula test` or `regula run` should align with the package name imported into the Rego test file, as explained in [this note](test-inputs.md#a-note-about-test-input-package-names).
+
+## Test a rule via `regula test`
+
+To test one or more rules via [`regula test`](../usage.md#test):
+
+```
+regula test path/to/rule path/to/tests path/to/IaC
+```
+
+- Example:
+
+        regula test rules/my_rule.rego tests/my_rule_test.rego infra/my_infra.tf
+
+- Example:
+
+        regula test .
+
+You'll see output like this:
+
+```
+PASS: 142/142
+```
+
+## Test a rule via `regula repl`
+
+To test interactively test one or more rules via [`regula repl`](../usage.md#repl):
+
+1. Load the tests, rule, and IaC files into the REPL:
+
+        regula repl path/to/rule path/to/tests path/to/IaC
+
+    Example:
+    
+        regula repl rules/my_rule.rego tests/my_rule_test.rego infra/my_infra.tf
+        
+    Example:
+    
+        regula repl .
+
+2. Open the rule package:
+
+        package rules.my_rule
+
+3. Import the IaC package:
+
+        import data.infra.my_infra_tf
+
+4. Evaluate a test from your rule tests file:
+
+        data.rules.my_rule.allow with input as my_infra_tf.mock_resources["aws_s3_bucket.my_valid_bucket"]
+
+You'll see the result of the evaluation:
+
+```
+true
+```

--- a/docs/src/development/writing-rules.md
+++ b/docs/src/development/writing-rules.md
@@ -19,7 +19,7 @@ Regula rules are written in [Rego](https://www.openpolicyagent.org/docs/latest/p
 Simple rules are useful when the policy applies to a single resource type only,
 and you want to make simple yes/no decision.
 
-```rego
+```ruby
 # Rules must always be located right below the `rules` package.
 package rules.my_simple_rule
 
@@ -40,7 +40,7 @@ If you want to return more information to the user, you can also define a
 custom error message in a simple rule.
 This is done by writing a `deny[msg]` style rule.
 
-```rego
+```ruby
 package rules.simple_rule_custom_message
 resource_type = "aws_ebs_volume"
 
@@ -56,7 +56,7 @@ Advanced rules are harder to write, but more powerful. They allow you to
 observe different kinds of resource types and decide which specific resources
 are valid or invalid.
 
-```rego
+```ruby
 # Rules still must be located in the `rules` package.
 package rules.user_attached_policy
 
@@ -103,7 +103,7 @@ The `fugue` API consists of these functions for advanced rules:
 
 As stated above, the functions `fugue.deny_resource_with_message(resource, msg)` and `fugue.missing_resource_with_message(resource_type, msg)` allow Regula to display a custom `rule_message` in its report. This rule demonstrates both functions:
 
-```rego hl_lines="17 21"
+```ruby hl_lines="17 21"
 package rules.account_password_policy
 
 import data.fugue
@@ -154,7 +154,7 @@ Here's an example rule result demonstrating a missing resource message:
 
 You can add metadata to a rule to enhance Regula's [report](../report.md):
 
-```
+```ruby
 __rego__metadoc__ := {
   "id": "CUSTOM_0001",
   "title": "IAM policies must have a description of at least 25 characters",
@@ -204,7 +204,7 @@ Here's an example rule result to show how this metadata looks in the report:
 
 CloudFormation rules are written the same way Terraform rules are, but require the line `input_type := "cfn"`, as shown in the simple rule below:
 
-```rego hl_lines="3"
+```ruby hl_lines="3"
 package rules.cfn_ebs_volume_encryption
 
 input_type := "cfn"

--- a/docs/src/development/writing-rules.md
+++ b/docs/src/development/writing-rules.md
@@ -1,5 +1,14 @@
 # Writing Rules
 
+Custom rule development generally has four parts:
+
+- Writing the IaC to be used as [test input](test-inputs.md)
+- Writing the rule (as documented on this page!)
+- Writing the [rule tests](writing-tests.md)
+- [Testing](testing-rules.md) the rules
+
+## Types of rules
+
 !!! tip
     For a tutorial on writing a simple custom rule, see [Example: Writing a Simple Rule](../examples/writing-a-rule.md).
 
@@ -25,7 +34,7 @@ allow {
 }
 ```
 
-### Custom error messages and attributes
+### Custom error messages and attributes (simple rules)
 
 If you want to return more information to the user, you can also define a
 custom error message in a simple rule.
@@ -80,14 +89,66 @@ policy[p] {
 }
 ```
 
-The `fugue` API consists of four functions:
+The `fugue` API consists of these functions for advanced rules:
 
 -   `fugue.resources(resource_type)` returns an object with all resources of
     the requested type.
 -   `fugue.allow_resource(resource)` marks a resource as valid.
 -   `fugue.deny_resource(resource)` marks a resource as invalid.
--   `fugue.missing_resource(resource_type)` marks a resource as **missing**.
-    This is useful if you for example _require_ a log group to be present.
+-   `fugue.deny_resource_with_message(resource, msg)` marks a resource as invalid and displays a custom `rule_message` in the report.
+-   `fugue.missing_resource(resource_type)` marks a resource as **missing**. This is useful if you for example _require_ a log group to be present.
+-   `fugue.missing_resource_with_message(resource_type, msg)` marks a resource as **missing** and displays a custom `rule_message` in the report.
+
+### Custom error messages (advanced rules)
+
+As stated above, the functions `fugue.deny_resource_with_message(resource, msg)` and `fugue.missing_resource_with_message(resource_type, msg)` allow Regula to display a custom `rule_message` in its report. This rule demonstrates both functions:
+
+```rego hl_lines="17 21"
+package rules.account_password_policy
+
+import data.fugue
+
+resource_type = "MULTIPLE"
+
+password_policies = fugue.resources("aws_iam_account_password_policy")
+
+policy[r] {
+  password_policy = password_policies[_]
+  password_policy.minimum_password_length >= 16
+  r = fugue.allow_resource(password_policy)
+} {
+  password_policy = password_policies[_]
+  not password_policy.minimum_password_length >= 16
+  msg = "Password policy is too short. It must be at least 16 characters."
+  r = fugue.deny_resource_with_message(password_policy, msg)
+} {
+  count(password_policies) == 0
+  msg = "No password policy exists."
+  r = fugue.missing_resource_with_message("aws_iam_account_password_policy", msg)
+}
+```
+
+Here's an example rule result demonstrating a missing resource message:
+
+```json hl_lines="12"
+    {
+      "controls": [
+        "CORPORATE-POLICY_1.1"
+      ],
+      "filepath": "main.tf",
+      "input_type": "tf",
+      "provider": "",
+      "resource_id": "",
+      "resource_type": "aws_iam_account_password_policy",
+      "rule_description": "Per company policy, an AWS account must have a password policy, and it must require a minimum of 16 characters",
+      "rule_id": "CUSTOM_0001",
+      "rule_message": "No password policy exists.",
+      "rule_name": "account_password_policy",
+      "rule_result": "FAIL",
+      "rule_severity": "Medium",
+      "rule_summary": "An AWS account must have a password policy requiring a minimum of 16 characters"
+    },
+```
 
 ## Adding rule metadata
 
@@ -125,7 +186,7 @@ Here's an example rule result to show how this metadata looks in the report:
         "CORPORATE-POLICY_1.1"
       ],
       "filepath": "../regula-ci-example/infra_tf/",
-      "platform": "terraform",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -138,3 +199,28 @@ Here's an example rule result to show how this metadata looks in the report:
       "rule_summary": "IAM policies must have a description of at least 25 characters"
     }
 ```
+
+## CloudFormation vs. Terraform rules
+
+CloudFormation rules are written the same way Terraform rules are, but require the line `input_type := "cfn"`, as shown in the simple rule below:
+
+```rego hl_lines="3"
+package rules.cfn_ebs_volume_encryption
+
+input_type := "cfn"
+
+resource_type := "AWS::EC2::Volume"
+
+default allow = false
+
+allow {
+  input.Encrypted == true
+}
+```
+
+Terraform rules do not require `input_type` to be explicitly set.
+
+Additionally, the `resource_type` is specified differently for CloudFormation and Terraform:
+
+- [CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) (e.g., `AWS::EC2::Instance`)
+- Terraform [AWS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs), [Azure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs), [Google Cloud](https://registry.terraform.io/providers/hashicorp/google/latest/docs) resource types (e.g., `aws_instance`)

--- a/docs/src/development/writing-tests.md
+++ b/docs/src/development/writing-tests.md
@@ -15,7 +15,7 @@ For a deep dive into test input, see [Test Inputs](test-inputs.md).
 
 Suppose you're writing a **simple rule** that checks whether AWS EBS volumes are encrypted:
 
-```rego
+```ruby
 package rules.tf_aws_ebs_volume_encrypted
 
 resource_type = "aws_ebs_volume"
@@ -74,7 +74,7 @@ Here's the **test IaC** you might use as test input, containing a valid (encrypt
 
 Finally, here is the **test file** for the simple rule. It contains two tests, a valid and invalid case. Note that because this is a simple rule, `mock_resources` is imported as [test input](test-inputs.md) (see [this note](test-inputs.md#a-note-about-test-input-package-names) about the package name):
 
-```rego hl_lines="3"
+```ruby hl_lines="3"
 package rules.tf_aws_ebs_volume_encrypted_simple
 
 import data.volume_encrypted_infra_tf.mock_resources
@@ -92,7 +92,7 @@ test_invalid_ebs_volume_encrypted {
 
 Suppose you've written an **advanced rule** that checks whether AWS EBS volumes are encrypted. For this example, we've just converted the simple rule above to an advanced rule:
 
-```rego
+```ruby
 package rules.tf_aws_ebs_volume_encrypted_advanced
 
 import data.fugue
@@ -161,7 +161,7 @@ You can use the **same test IaC** for test input, but this time, you'd use the [
 
 Finally, here is the **test file** for the advanced rule. It contains one test that checks a valid and invalid case. Because we're testing an advanced rule, `mock_input` is imported as [test input](test-inputs.md) (see [this note](test-inputs.md#a-note-about-test-input-package-names) about the package name):
 
-```rego hl_lines="3"
+```ruby hl_lines="3"
 package rules.tf_aws_ebs_volume_encrypted_advanced
 
 import data.volume_encrypted_infra_tf.mock_input

--- a/docs/src/development/writing-tests.md
+++ b/docs/src/development/writing-tests.md
@@ -1,0 +1,182 @@
+# Writing Tests
+
+Consult [OPA's documentation](https://www.openpolicyagent.org/docs/latest/policy-testing/) for general information on writing test rules, whose names must begin with `test_` (e.g., `test_my_rule`).
+
+Test inputs start with an IaC file. Regula dynamically generates various kinds of test inputs from a single IaC file.
+
+The test input used for simple and advanced rules is different:
+
+- [Simple rules](writing-rules.md#simple-rules) use `mock_resources` test input.
+- [Advanced rules](writing-rules.md#advanced-rules) use `mock_input` test input.
+
+For a deep dive into test input, see [Test Inputs](test-inputs.md).
+
+### Writing a test for a simple rule
+
+Suppose you're writing a **simple rule** that checks whether AWS EBS volumes are encrypted:
+
+```rego
+package rules.tf_aws_ebs_volume_encrypted
+
+resource_type = "aws_ebs_volume"
+
+default allow = false
+
+allow {
+  input.encrypted == true
+}
+```
+
+Here's the **test IaC** you might use as test input, containing a valid (encrypted) and invalid (unencrypted) EBS volume, and the [**`mock_resources`**](test-inputs.md) Regula generates from it:
+
+=== "volume_encrypted_infra.tf"
+
+    ```tf
+    provider "aws" {
+      region = "us-east-2"
+    }
+
+    resource "aws_ebs_volume" "good" {
+      availability_zone = "us-west-2a"
+      size              = 40
+      encrypted         = true
+    }
+
+    resource "aws_ebs_volume" "bad" {
+      availability_zone = "us-west-2a"
+      size              = 40
+      encrypted         = false
+    }
+    ```
+
+=== "mock_resources"
+
+    ```json
+    {
+      "aws_ebs_volume.bad": {
+        "_provider": "aws",
+        "_type": "aws_ebs_volume",
+        "availability_zone": "us-west-2a",
+        "encrypted": false,
+        "id": "aws_ebs_volume.bad",
+        "size": 40
+      },
+      "aws_ebs_volume.good": {
+        "_provider": "aws",
+        "_type": "aws_ebs_volume",
+        "availability_zone": "us-west-2a",
+        "encrypted": true,
+        "id": "aws_ebs_volume.good",
+        "size": 40
+      }
+    }
+    ```
+
+Finally, here is the **test file** for the simple rule. It contains two tests, a valid and invalid case. Note that because this is a simple rule, `mock_resources` is imported as [test input](test-inputs.md) (see [this note](test-inputs.md#a-note-about-test-input-package-names) about the package name):
+
+```rego hl_lines="3"
+package rules.tf_aws_ebs_volume_encrypted_simple
+
+import data.volume_encrypted_infra_tf.mock_resources
+
+test_valid_ebs_volume_encrypted {
+  allow with input as mock_resources["aws_ebs_volume.good"]
+}
+
+test_invalid_ebs_volume_encrypted {
+  not allow with input as mock_resources["aws_ebs_volume.bad"]
+}
+```
+
+### Writing a test for an advanced rule
+
+Suppose you've written an **advanced rule** that checks whether AWS EBS volumes are encrypted. For this example, we've just converted the simple rule above to an advanced rule:
+
+```rego
+package rules.tf_aws_ebs_volume_encrypted_advanced
+
+import data.fugue
+
+resource_type = "MULTIPLE"
+
+volumes = fugue.resources("aws_ebs_volume")
+
+policy[p] {
+  volume = volumes[_]
+  volume.encrypted == true
+  p = fugue.allow_resource(volume)
+} {
+  volume = volumes[_]
+  volume.encrypted == false
+  p = fugue.deny_resource(volume)
+}
+```
+
+You can use the **same test IaC** for test input, but this time, you'd use the [**`mock_input`**](test-inputs.md):
+
+=== "volume_encrypted_infra.tf"
+
+    ```tf
+    provider "aws" {
+      region = "us-east-2"
+    }
+
+    resource "aws_ebs_volume" "good" {
+      availability_zone = "us-west-2a"
+      size              = 40
+      encrypted         = true
+    }
+
+    resource "aws_ebs_volume" "bad" {
+      availability_zone = "us-west-2a"
+      size              = 40
+      encrypted         = false
+    }
+    ```
+
+=== "mock_input"
+
+    ```json
+    {
+      "resources": {
+        "aws_ebs_volume.bad": {
+          "_provider": "aws",
+          "_type": "aws_ebs_volume",
+          "availability_zone": "us-west-2a",
+          "encrypted": false,
+          "id": "aws_ebs_volume.bad",
+          "size": 40
+        },
+        "aws_ebs_volume.good": {
+          "_provider": "aws",
+          "_type": "aws_ebs_volume",
+          "availability_zone": "us-west-2a",
+          "encrypted": true,
+          "id": "aws_ebs_volume.good",
+          "size": 40
+        }
+      }
+    }
+    ```
+
+Finally, here is the **test file** for the advanced rule. It contains one test that checks a valid and invalid case. Because we're testing an advanced rule, `mock_input` is imported as [test input](test-inputs.md) (see [this note](test-inputs.md#a-note-about-test-input-package-names) about the package name):
+
+```rego hl_lines="3"
+package rules.tf_aws_ebs_volume_encrypted_advanced
+
+import data.volume_encrypted_infra_tf.mock_input
+
+test_ebs_volume_encrypted {
+  pol := policy with input as mock_input
+  resources := {p.id: p.valid | p := pol[_]}
+  resources["aws_ebs_volume.good"] == true
+  resources["aws_ebs_volume.bad"] == false
+}
+```
+
+!!! tip
+    To learn more about the types of test inputs and how to view them, see [Test Inputs](test-inputs.md).
+
+## Example rules and tests
+
+You can view the [Regula library of rules](https://github.com/fugue/regula/tree/master/rego/rules) and accompanying [tests](https://github.com/fugue/regula/tree/master/rego/tests/rules) for reference. You'll also find some [example rules](https://github.com/fugue/regula/tree/master/rego/examples/aws) and [their tests](https://github.com/fugue/regula/tree/master/rego/tests/examples/aws) in the repo.

--- a/docs/src/examples/waive-and-disable.md
+++ b/docs/src/examples/waive-and-disable.md
@@ -43,8 +43,8 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -60,8 +60,8 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -77,8 +77,8 @@ We see this output:
       "controls": [
         "CIS-AWS_v1.2.0_1.22"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -94,8 +94,8 @@ We see this output:
       "controls": [
         "CIS-AWS_v1.2.0_1.22"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -106,15 +106,16 @@ We see this output:
       "rule_result": "PASS",
       "rule_severity": "High",
       "rule_summary": "IAM policies should not have full \"*:*\" administrative privileges"
-    }
+    },
+    <cut for length>
   ],
   "summary": {
     "filepaths": [
-      "infra_tf"
+      "infra_tf/main.tf"
     ],
     "rule_results": {
       "FAIL": 2,
-      "PASS": 2,
+      "PASS": 4,
       "WAIVED": 0
     },
     "severities": {
@@ -175,8 +176,8 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -192,8 +193,8 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -209,8 +210,8 @@ We see this output:
       "controls": [
         "CIS-AWS_v1.2.0_1.22"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -226,8 +227,8 @@ We see this output:
       "controls": [
         "CIS-AWS_v1.2.0_1.22"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -239,14 +240,15 @@ We see this output:
       "rule_severity": "High",
       "rule_summary": "IAM policies should not have full \"*:*\" administrative privileges"
     }
+    <cut for length>
   ],
   "summary": {
     "filepaths": [
-      "infra_tf"
+      "infra_tf/main.tf"
     ],
     "rule_results": {
       "FAIL": 1,
-      "PASS": 2,
+      "PASS": 4,
       "WAIVED": 1
     },
     "severities": {
@@ -261,7 +263,7 @@ We see this output:
 }
 ```
 
-This time, there are 1 FAIL, 2 PASS, and 1 WAIVED rule results! You can see in the output that the `rule_result` value is `WAIVED` for the rule `long_description` and resource `aws_iam_policy.basically_allow_all`.
+This time, there are 1 FAIL, 4 PASS, and 1 WAIVED rule results! You can see in the output that the `rule_result` value is `WAIVED` for the rule `long_description` and resource `aws_iam_policy.basically_allow_all`.
 
 Hooray! You've just configured Regula to waive a rule result for a resource. Your next mission: disabling a rule!
 
@@ -295,8 +297,8 @@ We'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -312,8 +314,8 @@ We'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -325,14 +327,15 @@ We'll see this output:
       "rule_severity": "Low",
       "rule_summary": "IAM policies must have a description of at least 25 characters"
     }
+    <cut for length>
   ],
   "summary": {
     "filepaths": [
-      "infra_tf"
+      "infra_tf/main.tf"
     ],
     "rule_results": {
       "FAIL": 0,
-      "PASS": 1,
+      "PASS": 3,
       "WAIVED": 1
     },
     "severities": {
@@ -347,7 +350,7 @@ We'll see this output:
 }
 ```
 
-Now there are just two rule results: 1 PASS and 1 WAIVED. As you can see, the rule `tf_aws_iam_admin_policy` was totally ignored.
+Now there are just 4 rule results: 3 PASS and 1 WAIVED. As you can see, the rule `tf_aws_iam_admin_policy` was totally ignored.
 
 Nice job! You just configured Regula to disable a rule. 
 

--- a/docs/src/examples/waive-and-disable.md
+++ b/docs/src/examples/waive-and-disable.md
@@ -138,7 +138,7 @@ Let's say we want to make an exception for this resource. We're going to waive t
 
 Copy the configuration below into a file named `config.rego` in the root of the `regula-ci-example` directory:
 
-```
+```ruby
 package fugue.regula.config
 
 waivers[waiver] {
@@ -273,7 +273,7 @@ For demonstrative purposes, let's [disable](../configuration.md#disabling-rules)
 
 Add the following chunk to the end of `config.rego`:
 
-```
+```ruby
 rules[rule] {
   rule := {
     "rule_name": "tf_aws_iam_admin_policy",

--- a/docs/src/examples/writing-a-rule.md
+++ b/docs/src/examples/writing-a-rule.md
@@ -18,7 +18,7 @@ We can rephrase this rule as "**Allow** a resource if its description is 25 or m
 
 First, we declare the package name. It should be unique, and it **must** start with `rules.` as we've done here:
 
-```
+```ruby
 package rules.long_description
 ```
 
@@ -26,7 +26,7 @@ package rules.long_description
 
 Adding metadata is optional but strongly encouraged, as it will make Regula's report much more useful:
 
-```
+```ruby
 __rego__metadoc__ := {
   "id": "CUSTOM_0001",
   "title": "IAM policies must have a description of at least 25 characters",
@@ -48,7 +48,7 @@ For details on each of these attributes, see [Adding rule metadata](../developme
 
 Next, specify the Terraform resource type. For simple rules, there must be exactly one `resource_type` declared, and in this case, that's [`aws_iam_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy):
 
-```
+```ruby
 resource_type = "aws_iam_policy"
 ```
 
@@ -58,7 +58,7 @@ When evaluating a rule with [OPA](https://www.openpolicyagent.org/docs/latest/),
 
 However, Regula expects a `false` rather than `undefined` value. We can provide an explicit `false` by setting a default value:
 
-```
+```ruby
 default allow = false
 ```
 
@@ -68,7 +68,7 @@ This way, if the input doesn't contain any resources that meet the `allow` condi
 
 If you're not very familiar with Rego, here's a tip. You can restate a Rego rule like so:
 
-```
+```ruby
 this variable = this value {
   if this condition is met
 }
@@ -76,7 +76,7 @@ this variable = this value {
 
 That means we can start with a skeleton of the `allow` rule (using some pseudocode):
 
-```
+```ruby
 allow = true {
   if this condition is met
 }
@@ -84,7 +84,7 @@ allow = true {
 
 In Rego, the default value given to a variable in the head of a rule is `true`, so you can omit the `= true` in this case:
 
-```
+```ruby
 allow {
   if this condition is met
 }
@@ -112,7 +112,7 @@ For more details on the package name format, see [our note about test inputs](..
 
 You'll see this output:
 
-```
+```json
 {
   "aws_iam_policy.basically_allow_all": {
     "_provider": "aws",
@@ -143,19 +143,19 @@ If you'd like to learn more about using the REPL for developing rules, take a de
 
 With simple rules, we always preface the attribute with `input.` because it represents the resource currently being examined by Regula. So now we have this:
 
-```
+```ruby
 input.description
 ```
 
 We can use the Rego built-in function [`count(collection_or_string)`](https://www.openpolicyagent.org/docs/latest/policy-reference/#aggregates) to check how many characters are in a string. Because we only want to allow strings that are 25 characters or more, our rule logic looks like this:
 
-```
+```ruby
   count(input.description) >= 25
 ```
 
 And when we put the condition inside the `allow` rule, we get this:
 
-```
+```ruby
 allow {
   count(input.description) >= 25
 }
@@ -165,7 +165,7 @@ allow {
 
 Now, here's the complete rule:
 
-```
+```ruby
 package rules.long_description
 
 __rego__metadoc__ := {
@@ -292,7 +292,7 @@ The process for writing custom rules to check CloudFormation is mostly the same 
 
 For instance, this is how you'd write `long_description` as a CloudFormation rule. Note that `resource_type` and `Description` are different from the Terraform rule, and `input_type` is present:
 
-```
+```ruby
 package rules.long_description_cfn
 
 __rego__metadoc__ := {

--- a/docs/src/examples/writing-a-rule.md
+++ b/docs/src/examples/writing-a-rule.md
@@ -94,7 +94,7 @@ Now we just need the condition. In this case, we want to allow a resource **if**
 
 ### Specify the attribute(s) to check
 
-First, we check how to specify the "description" attribute. The best way to do this is to check the [`mock_resources`](../development/rule-development.md#test-inputs) dynamically generated from the test IaC file. In this case, we'll use [infra_tf/main.tf](https://github.com/fugue/regula-ci-example/blob/master/infra_tf/main.tf) as our test file.
+First, we check how to specify the "description" attribute. The best way to do this is to check the [`mock_resources`](../development/test-inputs.md) dynamically generated from the test IaC file. In this case, we'll use [infra_tf/main.tf](https://github.com/fugue/regula-ci-example/blob/master/infra_tf/main.tf) as our test file.
 
 To view the `mock_resources`, let's fire up the [REPL](../usage.md#repl):
 
@@ -108,7 +108,7 @@ Now, we enter the package name of the input file, specifying `mock_resources` as
 data.infra_tf.main_tf.mock_resources
 ```
 
-For more details on the package name format, see [our note about test inputs](../development/rule-development.md#a-note-about-test-input).
+For more details on the package name format, see [our note about test inputs](../development/test-inputs.md#a-note-about-test-input-package-names).
 
 You'll see this output:
 
@@ -137,7 +137,7 @@ You'll see this output:
 
 Here you can see that there are two resources defined, both of the type `aws_iam_policy`. The attribute `description` is what we're looking for, and it's located at the level directly beneath the resource ID. That means it's a top-level attribute -- it's not nested under any other attribute.
 
-If you'd like to learn more about using the REPL for developing rules, take a detour to [Rule Development](../development/rule-development.md).
+If you'd like to learn more about using the REPL for developing rules, take a detour to [Test Inputs](../development/test-inputs.md).
 
 ### Specify the condition
 
@@ -232,8 +232,8 @@ You'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
@@ -249,8 +249,8 @@ You'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "infra_tf",
-      "platform": "terraform",
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
@@ -265,7 +265,7 @@ You'll see this output:
   ],
   "summary": {
     "filepaths": [
-      "infra_tf"
+      "infra_tf/main.tf"
     ],
     "rule_results": {
       "FAIL": 1,
@@ -288,7 +288,7 @@ As you can see, the IAM policy `aws_iam_policy.basically_deny_all` passed the cu
 
 ## CloudFormation example rule
 
-The process for writing custom rules to check CloudFormation is mostly the same as for Terraform -- the main difference is how you specify the resource type and attribute to check. Additionally, you need to specify `input_type := "cloudformation"` somewhere in the rule.
+The process for writing custom rules to check CloudFormation is mostly the same as for Terraform -- the main difference is how you specify the resource type and attribute to check. Additionally, you need to specify `input_type := "cfn"` somewhere in the rule.
 
 For instance, this is how you'd write `long_description` as a CloudFormation rule. Note that `resource_type` and `Description` are different from the Terraform rule, and `input_type` is present:
 
@@ -309,7 +309,7 @@ __rego__metadoc__ := {
   }
 }
 
-input_type := "cloudformation"
+input_type := "cfn"
 
 resource_type = "AWS::IAM::ManagedPolicy"
 

--- a/docs/src/integrations/pre-commit.md
+++ b/docs/src/integrations/pre-commit.md
@@ -1,0 +1,65 @@
+# Regula Pre-Commit Hook
+
+You can run Regula in a [pre-commit](https://pre-commit.com/) hook. Whenever you `git commit` IaC, Regula will check it for security and compliance first. If there are violations, you'll need to remediate them before you can commit the code.
+
+The pre-commit hook below:
+
+- Checks changed Terraform HCL files anywhere in the local repo
+- Checks changed CloudFormation templates in `/src`
+- Outputs test results in TAP format
+
+## Hook installation
+
+1. Install pre-commit:
+
+    ```
+    pip install pre-commit
+    ```
+
+2. Copy the code below and save it as `.pre-commit-config.yaml` in the root of the repo you want to check:
+
+    ```yaml
+    repos:
+      - repo: local
+        hooks:
+        - id: regula-cfn
+          name: Regula for CloudFormation
+          entry: regula run -f tap -t cfn
+          language: system
+          files: ^src/.*(yaml)$
+      - repo: local
+        hooks:
+        - id: regula-tf
+          name: Regula for Terraform HCL
+          entry: regula run -f tap -t tf
+          language: system
+          files: .*(tf)
+    ```
+
+3. Install the pre-commit hook:
+
+    ```
+    pre-commit install
+    ```
+
+4. *Optional (but recommended!):* Test the hook on all IaC in the repo:
+
+        pre-commit run --all-files
+
+When you commit IaC now, Regula will check it for security and compliance issues.
+
+## Example output
+
+```tap
+± git commit -m "Update network security rule"
+Regula for CloudFormation................................................Passed
+Regula for Terraform HCL.................................................Failed
+- hook id: regula-tf
+- exit code: 1
+
+ok 0 azurerm_network_security_group.devnsg: Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)
+not ok 1 azurerm_network_security_group.devnsg: Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)
+ok 2 azurerm_storage_account.main: Storage Accounts 'Secure transfer required' should be enabled
+ok 3 azurerm_storage_account.main: Storage accounts should deny access from all networks by default
+ok 4 azurerm_storage_account.main: Storage accounts 'Trusted Microsoft Services' access should be enabled
+```

--- a/docs/src/integrations/travis.md
+++ b/docs/src/integrations/travis.md
@@ -1,3 +1,3 @@
 # Regula + Travis CI
 
-We've provided an example configuration file for integrating Regula and [Travis CI](https://www.travis-ci.com/) in a CI/CD pipeline. See the [regula-ci-example](https://github.com/fugue/regula-ci-example/blob/master/.travis.yml) repository for details.
+We've provided an example configuration file for integrating Regula and [Travis CI](https://www.travis-ci.com/) in a CI/CD pipeline. See the [regula-travis-example](https://github.com/fugue/regula-travis-example) repository for details and a walkthrough.

--- a/docs/src/report.md
+++ b/docs/src/report.md
@@ -10,7 +10,7 @@ Here's a snippet of test results from a Regula JSON report:
         "CIS-AWS_v1.3.0_1.20"
       ],
       "filepath": "../test_infra/cfn/cfntest2.yaml",
-      "platform": "cloudformation",
+      "input_type": "cfn",
       "provider": "aws",
       "resource_id": "S3Bucket1",
       "resource_type": "AWS::S3::Bucket",
@@ -27,7 +27,7 @@ Here's a snippet of test results from a Regula JSON report:
         "CIS-AWS_v1.3.0_2.1.1"
       ],
       "filepath": "../test_infra/cfn/cfntest2.yaml",
-      "platform": "cloudformation",
+      "input_type": "cfn",
       "provider": "aws",
       "resource_id": "S3BucketLogs",
       "resource_type": "AWS::S3::Bucket",
@@ -44,7 +44,7 @@ Here's a snippet of test results from a Regula JSON report:
         "CIS-Google_v1.0.0_3.6"
       ],
       "filepath": "../test_infra/tf/",
-      "platform": "terraform",
+      "input_type": "tf",
       "provider": "google",
       "resource_id": "google_compute_firewall.rule-2",
       "resource_type": "google_compute_firewall",

--- a/docs/src/rules.md
+++ b/docs/src/rules.md
@@ -1,3 +1,226 @@
 # Rules List
 
-To view the full list of Regula rules, see our [GitHub repo](https://github.com/fugue/regula/tree/master/rego/rules).
+To view the Rego code for the rules below, see our [GitHub repo](https://github.com/fugue/regula/tree/master/rego/rules).
+
+!!! tip
+    Click on a column to sort alphabetically by that category, and click it again to reverse the sort order.
+
+## AWS
+|                                                               Summary                                                                |      Resource Types       |Severity| Rule ID |
+|--------------------------------------------------------------------------------------------------------------------------------------|---------------------------|--------|---------|
+|IAM password policies should prevent reuse of previously used passwords                                                               |MULTIPLE                   |Medium  |FG_R00002|
+|IAM password policies should expire passwords within 90 days                                                                          |MULTIPLE                   |Medium  |FG_R00003|
+|IAM policies should not be attached to users                                                                                          |MULTIPLE                   |Low     |FG_R00007|
+|IAM policies should not be attached directly to users                                                                                 |MULTIPLE                   |Low     |FG_R00007|
+|CloudFront distribution origin should be set to S3 or origin protocol policy should be set to https-only                              |MULTIPLE                   |Medium  |FG_R00010|
+|CloudFront viewer protocol policy should be set to https-only or redirect-to-https                                                    |aws_cloudfront_distribution|Medium  |FG_R00011|
+|ELBv1 listener protocol should not be set to http                                                                                     |MULTIPLE                   |High    |FG_R00013|
+|Auto Scaling groups should span two or more availability zones                                                                        |MULTIPLE                   |Medium  |FG_R00014|
+|EBS volume encryption should be enabled                                                                                               |AWS::EC2::Volume           |High    |FG_R00016|
+|EBS volume encryption should be enabled                                                                                               |aws_ebs_volume             |High    |FG_R00016|
+|CloudFront distributions should have geo-restrictions specified                                                                       |MULTIPLE                   |Medium  |FG_R00018|
+|IAM password policies should require at least one uppercase character                                                                 |MULTIPLE                   |Medium  |FG_R00021|
+|IAM password policies should require at least one lowercase character                                                                 |MULTIPLE                   |Medium  |FG_R00022|
+|IAM password policies should require at least one symbol                                                                              |MULTIPLE                   |Medium  |FG_R00023|
+|IAM password policies should require at least one number                                                                              |MULTIPLE                   |Medium  |FG_R00024|
+|IAM password policies should require a minimum length of 14                                                                           |MULTIPLE                   |Medium  |FG_R00025|
+|CloudTrail log file validation should be enabled                                                                                      |AWS::CloudTrail::Trail     |Medium  |FG_R00027|
+|CloudTrail log file validation should be enabled                                                                                      |aws_cloudtrail             |Medium  |FG_R00027|
+|S3 bucket ACLs should not have public access on S3 buckets that store CloudTrail log files                                            |MULTIPLE                   |Critical|FG_R00028|
+|S3 bucket ACLs should not have public access on S3 buckets that store CloudTrail log files                                            |MULTIPLE                   |Critical|FG_R00028|
+|CloudTrail trails should have CloudWatch log integration enabled                                                                      |AWS::CloudTrail::Trail     |Medium  |FG_R00029|
+|CloudTrail trails should have CloudWatch log integration enabled                                                                      |MULTIPLE                   |Medium  |FG_R00029|
+|S3 bucket access logging should be enabled on S3 buckets that store CloudTrail log files                                              |MULTIPLE                   |Medium  |FG_R00031|
+|S3 bucket access logging should be enabled on S3 buckets that store CloudTrail log files                                              |MULTIPLE                   |Medium  |FG_R00031|
+|CloudTrail log files should be encrypted using KMS CMKs                                                                               |AWS::CloudTrail::Trail     |High    |FG_R00035|
+|CloudTrail log files should be encrypted using KMS CMKs                                                                               |MULTIPLE                   |High    |FG_R00035|
+|KMS CMK rotation should be enabled                                                                                                    |AWS::KMS::Key              |Medium  |FG_R00036|
+|KMS CMK rotation should be enabled                                                                                                    |aws_kms_key                |Medium  |FG_R00036|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 5900 (Virtual Network Computing)                  |MULTIPLE                   |High    |FG_R00037|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 5800 (Virtual Network Computing), unless from ELBs|MULTIPLE                   |High    |FG_R00038|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 5500 (Virtual Network Computing)                  |MULTIPLE                   |High    |FG_R00039|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 23 (Telnet)                                       |MULTIPLE                   |High    |FG_R00040|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 80 (HTTP), unless from ELBs                       |MULTIPLE                   |High    |FG_R00041|
+|ELBv1 load balancer cross zone load balancing should be enabled                                                                       |MULTIPLE                   |Medium  |FG_R00043|
+|VPC security group inbound rules should not permit ingress from a public address to all ports and protocols                           |aws_security_group         |High    |FG_R00044|
+|VPC security group inbound rules should not permit ingress from '0.0.0.0/0' to all ports and protocols                                |MULTIPLE                   |High    |FG_R00045|
+|SQS access policies should not have global "*.*" access                                                                               |MULTIPLE                   |Critical|FG_R00049|
+|SNS subscriptions should deny access via HTTP                                                                                         |MULTIPLE                   |Medium  |FG_R00052|
+|VPC flow logging should be enabled                                                                                                    |MULTIPLE                   |Medium  |FG_R00054|
+|VPC flow logging should be enabled                                                                                                    |MULTIPLE                   |Medium  |FG_R00054|
+|Load balancer access logging should be enabled                                                                                        |MULTIPLE                   |Medium  |FG_R00066|
+|CloudFront access logging should be enabled                                                                                           |MULTIPLE                   |Medium  |FG_R00067|
+|CloudWatch log groups should be encrypted with KMS CMKs                                                                               |MULTIPLE                   |Medium  |FG_R00068|
+|DynamoDB tables should be encrypted with AWS or customer managed KMS CMKs                                                             |MULTIPLE                   |Medium  |FG_R00069|
+|SQS queue server-side encryption should be enabled (AWS-managed keys)                                                                 |MULTIPLE                   |High    |FG_R00070|
+|CloudFront distributions should be protected by WAFs                                                                                  |MULTIPLE                   |Medium  |FG_R00073|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH)                                          |MULTIPLE                   |High    |FG_R00085|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)                                                  |aws_security_group         |High    |FG_R00085|
+|IAM password policies should have a minimum length of 7 and include both alphabetic and numeric characters                            |MULTIPLE                   |Medium  |FG_R00086|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)                            |MULTIPLE                   |High    |FG_R00087|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)                            |aws_security_group         |High    |FG_R00087|
+|IAM password policies should prevent reuse of the four previously used passwords                                                      |MULTIPLE                   |Medium  |FG_R00088|
+|VPC default security group should restrict all traffic                                                                                |MULTIPLE                   |Medium  |FG_R00089|
+|VPC default security group should restrict all traffic                                                                                |MULTIPLE                   |Medium  |FG_R00089|
+|IAM policies should not have full "*:*" administrative privileges                                                                     |MULTIPLE                   |High    |FG_R00092|
+|IAM policies should not have full "*:*" administrative privileges                                                                     |MULTIPLE                   |High    |FG_R00092|
+|RDS instances should be encrypted (AWS-managed or customer-managed KMS CMKs)                                                          |MULTIPLE                   |High    |FG_R00093|
+|RDS instances should have FedRAMP approved database engines                                                                           |MULTIPLE                   |Low     |FG_R00094|
+|S3 bucket server side encryption should be enabled                                                                                    |AWS::S3::Bucket            |High    |FG_R00099|
+|S3 bucket server side encryption should be enabled                                                                                    |aws_s3_bucket              |High    |FG_R00099|
+|S3 bucket policies should only allow requests that use HTTPS                                                                          |MULTIPLE                   |Medium  |FG_R00100|
+|S3 bucket policies should only allow requests that use HTTPS                                                                          |MULTIPLE                   |Medium  |FG_R00100|
+|S3 bucket versioning and lifecycle policies should be enabled                                                                         |aws_s3_bucket              |Medium  |FG_R00101|
+|ELB listener security groups should not be set to TCP all                                                                             |MULTIPLE                   |High    |FG_R00102|
+|VPC security groups attached to EC2 instances should not permit ingress from '0.0.0.0/0' to all ports                                 |MULTIPLE                   |High    |FG_R00103|
+|VPC security groups attached to RDS instances should not permit ingress from '0.0.0.0/0' to all ports                                 |MULTIPLE                   |High    |FG_R00104|
+|ElastiCache transport encryption should be enabled                                                                                    |MULTIPLE                   |Medium  |FG_R00105|
+|DynamoDB tables Point in Time Recovery should be enabled                                                                              |MULTIPLE                   |Medium  |FG_R00106|
+|RDS instances should have backup retention periods configured                                                                         |MULTIPLE                   |Medium  |FG_R00107|
+|RDS Aurora cluster multi-AZ should be enabled                                                                                         |MULTIPLE                   |Medium  |FG_R00209|
+|S3 bucket policies should not allow all actions for all IAM principals and public users                                               |MULTIPLE                   |High    |FG_R00210|
+|S3 bucket policies should not allow list actions for all IAM principals and public users                                              |MULTIPLE                   |High    |FG_R00211|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 9200 (Elasticsearch)                              |MULTIPLE                   |High    |FG_R00212|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 9300 (Elasticsearch)                              |MULTIPLE                   |High    |FG_R00213|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 2379 (etcd)                                       |MULTIPLE                   |High    |FG_R00214|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 27017 (MongoDB)                                   |MULTIPLE                   |High    |FG_R00215|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 27018 (MongoDB)                                   |MULTIPLE                   |High    |FG_R00216|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 27019 (MongoDB)                                   |MULTIPLE                   |High    |FG_R00217|
+|IAM policies should not allow broad list actions on S3 buckets                                                                        |MULTIPLE                   |Medium  |FG_R00218|
+|IAM role trust policies should not allow all principals to assume the role                                                            |MULTIPLE                   |Medium  |FG_R00219|
+|IAM roles attached to instance profiles should not allow broad list actions on S3 buckets                                             |MULTIPLE                   |Medium  |FG_R00220|
+|S3 buckets should have all `block public access` options enabled                                                                      |AWS::S3::Bucket            |High    |FG_R00229|
+|S3 buckets should have all `block public access` options enabled                                                                      |MULTIPLE                   |High    |FG_R00229|
+|VPC security groups attached to EC2 instances should not permit ingress from '0.0.0.0/0' to TCP/UDP port 389 (LDAP)                   |MULTIPLE                   |High    |FG_R00234|
+|CloudTrail trails should be configured to log management events                                                                       |aws_cloudtrail             |Medium  |FG_R00237|
+|CloudWatch alarms should have at least one alarm action, one INSUFFICIENT_DATA action, or one OK action enabled                       |aws_cloudwatch_metric_alarm|Medium  |FG_R00240|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 11214 (Memcached SSL)                             |aws_security_group         |High    |FG_R00242|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 11215 (Memcached SSL)                             |aws_security_group         |High    |FG_R00243|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 135 (MSSQL Debugger)                              |aws_security_group         |High    |FG_R00244|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 137 (NetBIOS Name Service)                        |aws_security_group         |High    |FG_R00245|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 138 (NetBios Datagram Service)                    |aws_security_group         |High    |FG_R00246|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 139 (NetBios Session Service)                     |aws_security_group         |High    |FG_R00247|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 1433 (MSSQL Server)                               |aws_security_group         |High    |FG_R00248|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 1434 (MSSQL Admin)                                |aws_security_group         |High    |FG_R00249|
+|Require Multi Availability Zones turned on for RDS Instances                                                                          |MULTIPLE                   |Medium  |FG_R00251|
+|KMS master keys should not be publicly accessible                                                                                     |aws_kms_key                |Critical|FG_R00252|
+|EC2 instances should use IAM roles and instance profiles instead of IAM access keys to perform requests                               |aws_instance               |High    |FG_R00253|
+|IAM roles used for trust relationships should have MFA or external IDs                                                                |aws_iam_role               |High    |FG_R00255|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 2382 (SQL Server Analysis Services browser)       |aws_security_group         |High    |FG_R00256|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 2383 (SQL Server Analysis Services)               |aws_security_group         |High    |FG_R00257|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 2484 (Oracle DB SSL)                              |aws_security_group         |High    |FG_R00258|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3000 (Ruby on Rails web server)                   |aws_security_group         |High    |FG_R00259|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3020 (CIFS / SMB)                                 |aws_security_group         |High    |FG_R00260|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 3306 (MySQL)                                      |aws_security_group         |High    |FG_R00261|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 4505 (SaltStack Master)                           |aws_security_group         |High    |FG_R00262|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 4506 (SaltStack Master)                           |aws_security_group         |High    |FG_R00263|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 5432 (PostgreSQL)                                 |aws_security_group         |High    |FG_R00264|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP port 61621 (Cassandra OpsCenter Agent)                     |aws_security_group         |High    |FG_R00265|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP port 636 (LDAP SSL)                                        |aws_security_group         |High    |FG_R00266|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP port 7001 (Cassandra)                                      |aws_security_group         |High    |FG_R00267|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' to TCP/UDP port 8000 (HTTP Alternate)                             |aws_security_group         |High    |FG_R00268|
+|Redshift cluster 'Publicly Accessible' should not be enabled                                                                          |aws_redshift_cluster       |Critical|FG_R00270|
+|EC2 instances should not have a public IP association (IPv4)                                                                          |aws_instance               |Medium  |FG_R00271|
+|IAM users should be members of at least one group                                                                                     |MULTIPLE                   |Low     |FG_R00272|
+|S3 bucket access logging should be enabled                                                                                            |aws_s3_bucket              |Medium  |FG_R00274|
+|S3 bucket replication (cross-region or same-region) should be enabled                                                                 |aws_s3_bucket              |Medium  |FG_R00275|
+|Lambda function policies should not allow global access                                                                               |MULTIPLE                   |High    |FG_R00276|
+|Lambda function policies should not allow global access                                                                               |MULTIPLE                   |High    |FG_R00276|
+|S3 buckets should not be publicly readable                                                                                            |MULTIPLE                   |Critical|FG_R00277|
+|RDS instance 'Publicly Accessible' should not be enabled                                                                              |aws_db_instance            |High    |FG_R00278|
+|S3 bucket policies and ACLs should not be configured for public read access                                                           |MULTIPLE                   |High    |FG_R00279|
+|RDS instance 'Deletion Protection' should be enabled                                                                                  |aws_db_instance            |Medium  |FG_R00280|
+|VPC security group inbound rules should not permit ingress from any address to all ports and protocols                                |aws_security_group         |Medium  |FG_R00350|
+|S3 bucket object-level logging for write events should be enabled                                                                     |MULTIPLE                   |Low     |FG_R00354|
+|S3 bucket object-level logging for read events should be enabled                                                                      |MULTIPLE                   |Low     |FG_R00355|
+|VPC network ACLs should not allow ingress from 0.0.0.0/0 to port 22                                                                   |MULTIPLE                   |High    |FG_R00357|
+|VPC network ACLs should not allow ingress from 0.0.0.0/0 to port 3389                                                                 |MULTIPLE                   |High    |FG_R00359|
+|API Gateway classic custom domains should use secure TLS protocol versions (1.2 and above)                                            |MULTIPLE                   |Medium  |FG_R00375|
+|API Gateway v2 custom domains should use secure TLS protocol versions (1.2 and above)                                                 |MULTIPLE                   |Medium  |FG_R00376|
+|VPC security group rules should not permit ingress from '0.0.0.0/0' except to ports 80 and 443                                        |aws_security_group         |        |FG_R00377|
+
+## Azure
+|                                                   Summary                                                    |      Resource Types       |Severity| Rule ID |
+|--------------------------------------------------------------------------------------------------------------|---------------------------|--------|---------|
+|Storage Accounts 'Secure transfer required' should be enabled                                                 |azurerm_storage_account    |Medium  |FG_R00152|
+|Storage accounts should deny access from all networks by default                                              |azurerm_storage_account    |High    |FG_R00154|
+|Network security group rules should not permit ingress from '0.0.0.0/0' to port 3389 (Remote Desktop Protocol)|MULTIPLE                   |High    |FG_R00190|
+|Network security group rules should not permit ingress from '0.0.0.0/0' to port 22 (SSH)                      |MULTIPLE                   |High    |FG_R00191|
+|SQL Server firewall rules should not permit ingress from 0.0.0.0/0 to all ports and protocols                 |azurerm_sql_firewall_rule  |High    |FG_R00192|
+|Virtual Machines data disks (non-boot volumes) should be encrypted                                            |MULTIPLE                   |High    |FG_R00196|
+|Virtual Machines unattached disks should be encrypted                                                         |MULTIPLE                   |High    |FG_R00197|
+|Blob Storage containers should have public access disabled                                                    |azurerm_storage_container  |Critical|FG_R00207|
+|Storage accounts 'Trusted Microsoft Services' access should be enabled                                        |azurerm_storage_account    |Medium  |FG_R00208|
+|SQL Server firewall rules should not permit start and end IP addresses to be 0.0.0.0                          |MULTIPLE                   |High    |FG_R00221|
+|MySQL Database server firewall rules should not permit start and end IP addresses to be 0.0.0.0               |MULTIPLE                   |High    |FG_R00222|
+|PostgreSQL Database server firewall rules should not permit start and end IP addresses to be 0.0.0.0          |MULTIPLE                   |High    |FG_R00223|
+|Ensure Azure Application Gateway Web application firewall (WAF) is enabled                                    |MULTIPLE                   |Medium  |FG_R00224|
+|MySQL Database server 'enforce SSL connection' should be enabled                                              |azurerm_mysql_server       |Medium  |FG_R00225|
+|PostgreSQL Database server 'enforce SSL connection' should be enabled                                         |azurerm_postgresql_server  |Medium  |FG_R00226|
+|Key Vault 'Enable Soft Delete' and 'Enable Purge Protection' should be enabled                                |azurerm_key_vault          |Medium  |FG_R00227|
+|SQL Server auditing should be enabled                                                                         |MULTIPLE                   |Medium  |FG_R00282|
+|SQL Server auditing retention should be greater than 90 days                                                  |MULTIPLE                   |Medium  |FG_R00283|
+|Virtual Network security group flow log retention period should be set to 90 days or greater                  |MULTIPLE                   |Medium  |FG_R00286|
+|Active Directory custom subscription owner roles should not be created                                        |azurerm_role_definition    |Medium  |FG_R00288|
+|PostgreSQL Database configuration 'log_checkpoints' should be on                                              |MULTIPLE                   |Medium  |FG_R00317|
+|PostgreSQL Database configuration 'log_connections' should be on                                              |MULTIPLE                   |Medium  |FG_R00318|
+|Azure Kubernetes Service instances should have RBAC enabled                                                   |azurerm_kubernetes_cluster |Medium  |FG_R00329|
+|PostgreSQL Database configuration 'log_disconnections' should be on                                           |MULTIPLE                   |Medium  |FG_R00331|
+|PostgreSQL Database configuration 'log_duration' should be on                                                 |MULTIPLE                   |Medium  |FG_R00333|
+|PostgreSQL Database configuration 'connection_throttling' should be on                                        |MULTIPLE                   |Medium  |FG_R00335|
+|PostgreSQL Database configuration 'log_retention days' should be greater than 3                               |MULTIPLE                   |Medium  |FG_R00337|
+|Monitor 'Activity Log Retention' should be 365 days or greater                                                |azurerm_monitor_log_profile|Medium  |FG_R00340|
+|Monitor audit profile should log all activities                                                               |azurerm_monitor_log_profile|Medium  |FG_R00341|
+|Monitor log profile should have activity logs for global services and all regions                             |MULTIPLE                   |Medium  |FG_R00342|
+|Key Vault logging should be enabled                                                                           |MULTIPLE                   |Medium  |FG_R00344|
+|App Service web app authentication should be enabled                                                          |MULTIPLE                   |Medium  |FG_R00345|
+|App Service web apps should have 'HTTPS only' enabled                                                         |azurerm_app_service        |High    |FG_R00346|
+|App Service web apps should have 'Minimum TLS Version' set to '1.2'                                           |azurerm_app_service        |Medium  |FG_R00347|
+|App Service web apps should have 'Incoming client certificates' enabled                                       |azurerm_app_service        |Medium  |FG_R00348|
+
+## Google
+|                                                Summary                                                 |       Resource Types       |Severity| Rule ID |
+|--------------------------------------------------------------------------------------------------------|----------------------------|--------|---------|
+|KMS keys should be rotated every 90 days or less                                                        |google_kms_crypto_key       |Medium  |FG_R00378|
+|Service accounts should only have Google-managed service account keys                                   |MULTIPLE                    |Medium  |FG_R00383|
+|User-managed service accounts should not have admin privileges                                          |MULTIPLE                    |High    |FG_R00384|
+|IAM users should not have project-level 'Service Account User' or 'Service Account Token Creator' roles |MULTIPLE                    |High    |FG_R00385|
+|KMS keys should not be anonymously or publicly accessible                                               |MULTIPLE                    |Critical|FG_R00386|
+|IAM users should not have both KMS admin and any of the KMS encrypter/decrypter roles                   |MULTIPLE                    |Medium  |FG_R00388|
+|IAM default audit log config should include 'DATA_READ' and 'DATA_WRITE' log types                      |MULTIPLE                    |Medium  |FG_R00389|
+|IAM default audit log config should not exempt any users                                                |MULTIPLE                    |Medium  |FG_R00391|
+|Logging storage bucket retention policies and Bucket Lock should be configured                          |MULTIPLE                    |Medium  |FG_R00393|
+|DNS managed zone DNSSEC should be enabled                                                               |google_dns_managed_zone     |Medium  |FG_R00404|
+|DNS managed zone DNSSEC key-signing keys should not use RSASHA1                                         |google_dns_managed_zone     |High    |FG_R00405|
+|DNS managed zone DNSSEC zone-signing keys should not use RSASHA1                                        |google_dns_managed_zone     |High    |FG_R00406|
+|Network firewall rules should not permit ingress from 0.0.0.0/0 to port 22 (SSH)                        |google_compute_firewall     |High    |FG_R00407|
+|Network firewall rules should not permit ingress from 0.0.0.0/0 to port 3389 (RDP)                      |google_compute_firewall     |High    |FG_R00408|
+|Network subnet flow logs should be enabled                                                              |google_compute_subnetwork   |Medium  |FG_R00409|
+|Load balancer HTTPS or SSL proxy SSL policies should not have weak cipher suites                        |MULTIPLE                    |Medium  |FG_R00410|
+|Compute instances should not use the default service account                                            |google_compute_instance     |Medium  |FG_R00411|
+|Compute instances should not use the default service account with full access to all Cloud APIs         |google_compute_instance     |High    |FG_R00412|
+|Compute instance 'block-project-ssh-keys' should be enabled                                             |MULTIPLE                    |Medium  |FG_R00413|
+|Compute instances 'Enable connecting to serial ports' should not be enabled                             |MULTIPLE                    |High    |FG_R00415|
+|Compute instances 'IP forwarding' should not be enabled                                                 |google_compute_instance     |Low     |FG_R00416|
+|Compute instance disks should be encrypted with customer-supplied encryption keys (CSEKs)               |MULTIPLE                    |Medium  |FG_R00417|
+|Compute instance Shielded VM should be enabled                                                          |google_compute_instance     |Medium  |FG_R00418|
+|Compute instances should not have public IP addresses                                                   |google_compute_instance     |Medium  |FG_R00419|
+|Storage buckets should not be anonymously or publicly accessible                                        |MULTIPLE                    |Critical|FG_R00420|
+|Storage bucket uniform access control should be enabled                                                 |google_storage_bucket       |Medium  |FG_R00421|
+|MySQL database instance 'local_infile' database flag should be set to 'off'                             |MULTIPLE                    |Medium  |FG_R00423|
+|PostgreSQL database instance 'log_checkpoints' database flag should be set to 'on'                      |MULTIPLE                    |Medium  |FG_R00424|
+|PostgreSQL database instance 'log_connections' database flag should be set to 'on'                      |MULTIPLE                    |Medium  |FG_R00425|
+|PostgreSQL database instance 'log_disconnections' database flag should be set to 'on'                   |MULTIPLE                    |Medium  |FG_R00426|
+|PostgreSQL database instance 'log_lock_waits' database flag should be set to 'on'                       |MULTIPLE                    |Medium  |FG_R00427|
+|PostgreSQL database instance 'log_min_error_statement' database flag should be set appropriately        |MULTIPLE                    |Medium  |FG_R00428|
+|PostgreSQL database instance 'log_temp_files' database flag should be set to '0' (on)                   |MULTIPLE                    |Medium  |FG_R00429|
+|PostgreSQL database instance 'log_min_duration_statement' database flag should be set to '-1' (disabled)|MULTIPLE                    |Medium  |FG_R00430|
+|SQL Server database instance 'cross db ownership chaining' database flag should be set to 'off'         |MULTIPLE                    |Medium  |FG_R00431|
+|SQL Server database instance 'contained database authentication' database flag should be set to 'off'   |MULTIPLE                    |Medium  |FG_R00432|
+|SQL database instances should require incoming connections to use SSL                                   |google_sql_database_instance|Medium  |FG_R00433|
+|SQL database instances should not permit access from 0.0.0.0/0                                          |google_sql_database_instance|High    |FG_R00434|
+|SQL database instances should not have public IPs                                                       |google_sql_database_instance|Medium  |FG_R00435|
+|SQL database instance automated backups should be enabled                                               |google_sql_database_instance|Medium  |FG_R00436|
+|BigQuery datasets should not be anonymously or publicly accessible                                      |google_bigquery_dataset     |Critical|FG_R00437|
+|VPC subnet 'Private Google Access' should be enabled                                                    |google_compute_subnetwork   |Low     |FG_R00438|
+

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -559,7 +559,7 @@ Here's an example CloudFormation file and its generated test inputs file:
 
 === "cfn_resources_yaml.rego"
 
-    ```rego
+    ```ruby
     package infra.cfn_resources_yaml
 
     import data.fugue.resource_view.resource_view_input

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -195,7 +195,7 @@ Use the `--f | --format FORMAT` flag to specify the output format:
 
     CUSTOM_0001: IAM policies must have a description of at least 25 characters [Low]
 
-        [1]: AWS::IAM::ManagedPolicy.InvalidManagedPolicy01
+        [1]: InvalidManagedPolicy01
              in infra_cfn/invalid_long_description.yaml
 
     Found one problem.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,12 @@ nav:
     - "integrations/conftest.md"
     - "integrations/gh-actions.md"
     - "integrations/travis.md"
+    - "integrations/pre-commit.md"
   - Custom Rule Development:
-    - "development/rule-development.md"
     - "development/writing-rules.md"
+    - "development/writing-tests.md"
+    - "development/testing-rules.md"
+    - "development/test-inputs.md"
   - Examples:
     - "examples/waive-and-disable.md"
     - "examples/writing-a-rule.md"
@@ -78,3 +81,4 @@ plugins:
         "integrations/regula-conftest.md": "integrations/conftest.md"
         "integrations/regula-gh-actions.md": "integrations/gh-actions.md"
         "integrations/regula-travis.md": "integrations/travis.md"
+        "development/rule-development.md": "development/writing-rules.md"


### PR DESCRIPTION
This PR does the following:

- Redirects the Rule Development page to Writing Rules, and splits up the old Rule Development page into 3 pages:
  - Writing Tests
  - Testing Rules
  - Test Inputs
- Adds a pre-commit hook page
- Updates the Travis integration page to link to the new example repo
- Updates output throughout the docs
- Adds `write-test-inputs` documentation
- Adds table of rules to Rules List