### PR TITLE
[RM-5772] Add missing CIS-Azure_v1.3.0 mappings

### DIFF
--- a/rego/rules/tf/azurerm/network/security_group_no_inbound_22.rego
+++ b/rego/rules/tf/azurerm/network/security_group_no_inbound_22.rego
@@ -23,7 +23,10 @@ __rego__metadoc__ := {
   "custom": {
     "controls": {
       "CIS-Azure_v1.1.0": [
-        "CIS-Azure_v1.1.0_6.1"
+        "CIS-Azure_v1.1.0_6.2"
+      ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_6.2"
       ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_AC-4",

--- a/rego/rules/tf/azurerm/network/security_group_no_inbound_3389.rego
+++ b/rego/rules/tf/azurerm/network/security_group_no_inbound_3389.rego
@@ -23,7 +23,10 @@ __rego__metadoc__ := {
   "custom": {
     "controls": {
       "CIS-Azure_v1.1.0": [
-        "CIS-Azure_v1.1.0_6.2"
+        "CIS-Azure_v1.1.0_6.1"
+      ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_6.1"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/azurerm/sql/firewall_no_inbound_all.rego
+++ b/rego/rules/tf/azurerm/sql/firewall_no_inbound_all.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_6.3"
       ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_6.3"
+      ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_SC-7(5)"
       ]

--- a/rego/rules/tf/azurerm/storage/account_deny_access.rego
+++ b/rego/rules/tf/azurerm/storage/account_deny_access.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.7"
+      ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_3.6"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/azurerm/storage/account_microsoft_services.rego
+++ b/rego/rules/tf/azurerm/storage/account_microsoft_services.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.8"
+      ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_3.7"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/azurerm/storage/account_secure_transfer.rego
+++ b/rego/rules/tf/azurerm/storage/account_secure_transfer.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Azure_v1.1.0": [
         "CIS-Azure_v1.1.0_3.1"
+      ],
+      "CIS-Azure_v1.3.0": [
+        "CIS-Azure_v1.3.0_3.1"
       ]
     },
     "severity": "Medium"


### PR DESCRIPTION
These Azure rules were missing CIS-Azure_v1.3.0 mappings. I also fixed an issue with the v1.1.0 mappings where the RDP and SSH ingress controls were backwards.