### PR TITLE
Writing Tests page: Fix package name in Rego example

### DIFF
--- a/docs/src/development/writing-tests.md
+++ b/docs/src/development/writing-tests.md
@@ -16,7 +16,7 @@ For a deep dive into test input, see [Test Inputs](test-inputs.md).
 Suppose you're writing a **simple rule** that checks whether AWS EBS volumes are encrypted:
 
 ```ruby
-package rules.tf_aws_ebs_volume_encrypted
+package rules.tf_aws_ebs_volume_encrypted_simple
 
 resource_type = "aws_ebs_volume"
 


### PR DESCRIPTION
This PR fixes a small error on the [docs site](https://regula.dev/development/writing-tests.html#writing-a-test-for-a-simple-rule).