### PR TITLE
[RM-5805] Respect that some variables are not found

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -612,13 +612,7 @@ func (c *renderContext) RenderExpr(expr hclsyntax.Expression) interface{} {
 		return c.RenderExpr(e.Wrapped)
 	case *hclsyntax.ScopeTraversalExpr:
 		path := c.RenderTraversal(e.Traversal)
-		ref := c.resolve(path)
-		if ref != nil {
-			return ref
-		} else {
-			// Is this useful?  This should just map to variables?
-			return strings.Join(path, ".")
-		}
+		return c.resolve(path)
 	case *hclsyntax.TemplateExpr:
 		if len(e.Parts) == 1 {
 			return c.RenderExpr(e.Parts[0])

--- a/pkg/loader/tf_test/vars.json
+++ b/pkg/loader/tf_test/vars.json
@@ -1,0 +1,18 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.main": {
+        "_filepath": "tf_test/vars/main.tf",
+        "_provider": "aws",
+        "_type": "aws_s3_bucket",
+        "id": "aws_s3_bucket.main",
+        "tags": {
+          "department": "engineering",
+          "environment": null
+        }
+      }
+    }
+  },
+  "filepath": "tf_test/vars"
+}

--- a/pkg/loader/tf_test/vars/main.tf
+++ b/pkg/loader/tf_test/vars/main.tf
@@ -1,0 +1,15 @@
+variable "department" {
+  type = string
+  default = "engineering"
+}
+
+variable "environment" {
+  type = string
+}
+
+resource "aws_s3_bucket" "main" {
+  tags = {
+    department = var.department
+    environment = var.environment
+  }
+}


### PR DESCRIPTION
Just returning nil is important here as many terraform modules rely on
this failing to plug in variables using the ternary operator `?:`.