### PR TITLE
Fix missing results excluded from report

### DIFF
--- a/rego/lib/fugue.rego
+++ b/rego/lib/fugue.rego
@@ -88,6 +88,8 @@ missing(params) = ret {
     "type": params.resource_type,
     "message": object.get(params, "message", "invalid"),
     "provider": object.get(params, "provider", ""),
+    "attribute": null,
+    "filepath": "",
   }
 }
 


### PR DESCRIPTION
This PR fixes a bug where `missing()` rule results don't show up in the report output.