### PR TITLE
Set a default WORKDIR in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
+WORKDIR /workspace
 ENTRYPOINT [ "/usr/local/bin/regula" ]
 COPY regula /usr/local/bin/regula

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -25,13 +25,13 @@ brew upgrade regula
 
     === "macOS"
 
-        ```
+        ```shell
         mv regula /usr/local/bin
         ```
 
     === "Linux"
 
-        ```
+        ```shell
         sudo mv regula /usr/local/bin
         ```
 
@@ -41,6 +41,16 @@ brew upgrade regula
         md C:\regula\bin
         move regula.exe C:\regula\bin
         setx PATH "%PATH%;C:\regula\bin"
+        ```
+    
+    === "Windows (PowerShell)"
+
+        ```powershell
+        md C:\regula\bin
+        move regula.exe C:\regula\bin
+        $env:Path += ";C:\regula\bin"
+        # You can add '$env:Path += ";C:\regula\bin"' to your profile.ps1 file to
+        # persist that change across shell sessions.
         ```
 
 4. _Windows users only:_ Close cmd and re-open it so the changes take effect.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -629,16 +629,38 @@ Here's an example CloudFormation file and its generated test inputs file:
 
 Regula is available as a Docker image on DockerHub [here](https://hub.docker.com/r/fugue/regula).
 
-To run Regula on a single CloudFormation template or Terraform plan file, you can use the following command, passing in the template through standard input:
+The default `--workdir` for the Regula container is `/workspace`. To run Regula on your
+current working directory, you can use the following command:
 
-    docker run --rm -it fugue/regula:{{ version }} run < [IAC_TEMPLATE]
+=== "macOS and Linux"
 
-To run Regula on IaC directories or individual CloudFormation templates, HCL files, or Terraform plan JSON files, you can use the following command:
+    ```shell
+    docker run --rm -t -v $(pwd):/workspace fugue/regula:{{ version }} run
+    ```
 
-    docker run --rm -t \
-        -v $(pwd):/workspace \
-        --workdir /workspace \
-        fugue/regula:{{ version }} run template2.yaml tfdirectory1
+=== "Windows (PowerShell)"
+
+    ```powershell
+    docker run --rm -t -v ${pwd}:/workspace fugue/regula:{{ version }} run
+    ```
+
+To run Regula on specific directories or files, you can use the following command:
+
+=== "macOS and Linux"
+
+    ```shell
+    docker run --rm -t -v $(pwd):/workspace \
+      fugue/regula:{{ version }} run src/template2.yaml infra/tfdirectory1
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    # Note that we're using Unix-style paths in the arguments because
+    # fugue/regula is a Linux container.
+    docker run --rm -t -v ${pwd}:/workspace `
+      fugue/regula:{{ version }} run src/template2.yaml infra/tfdirectory1
+    ```
 
 When integrating this in a CI pipeline, we recommend pinning the regula version, e.g. `docker run fugue/regula:{{ version }}`.
 


### PR DESCRIPTION
This PR sets a default `WORKDIR` for the Regula Docker image. It makes the container a little easier to run since you don't have to specify the `--workdir` argument if you mount to `/workspace`. I also added PowerShell to the installation and Docker usage instructions.