### PR TITLE
[RM-5761] Smarter path join for tf loader

### DIFF
--- a/pkg/loader/loadpaths.go
+++ b/pkg/loader/loadpaths.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/fugue/regula/pkg/git"
 )
 
@@ -157,6 +159,7 @@ func (l *loadedConfigurations) AddConfiguration(path string, config IACConfigura
 	l.loadedPaths[path] = path
 	for _, f := range config.LoadedFiles() {
 		l.loadedPaths[f] = path
+		logrus.Debugf("loadedPaths[%s] -> %s", f, path)
 	}
 }
 

--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -1078,6 +1078,7 @@ func TfFilePathJoin(leading, trailing string) string {
 	} else if leading == "." {
 		return trailing
 	} else {
+		trailing = filepath.FromSlash(trailing)
 		sep := string(filepath.Separator)
 		trailing = strings.TrimPrefix(trailing, "." + sep)
 		return strings.TrimRight(leading, sep) + sep +

--- a/pkg/loader/tf_test.go
+++ b/pkg/loader/tf_test.go
@@ -184,3 +184,10 @@ func TestTfResourceLocation(t *testing.T) {
 		assert.Equal(t, i.expected, loc)
 	}
 }
+
+func TestTfFilePathJoin(t *testing.T) {
+	assert.Equal(t, loader.TfFilePathJoin(".", "examples/mssql/"), "examples/mssql/")
+	assert.Equal(t, loader.TfFilePathJoin("modules", "./examples/mssql/"), "modules/examples/mssql/")
+	assert.Equal(t, loader.TfFilePathJoin("examples/mssql/", "../../"), "examples/mssql/../../")
+	assert.Equal(t, loader.TfFilePathJoin("examples/mssql/", "./../../"), "examples/mssql/../../")
+}


### PR DESCRIPTION
Go's default filepath.Join reduces `examples/mssql/../../` to `.`.  This
doesn't really align with what we want.  We would want these three paths
to be different:

    .
    examples/mysql/../../
    examples/complete/../../

They represent the main module at `.`, and then two different instantations
of the main module at `.` loaded from different submodules.

By using our own join here we get the desired behaviour.  This helps for
determining the correct source code location in complex repositories.