### PR TITLE
[RM-5806] RDS publicly_accessible is false by default

### DIFF
--- a/rego/rules/tf/aws/rds/rds_instance_publicly_accessible.rego
+++ b/rego/rules/tf/aws/rds/rds_instance_publicly_accessible.rego
@@ -28,9 +28,9 @@ __rego__metadoc__ := {
 
 resource_type = "aws_db_instance"
 
-default allow = false
+default deny = false
 
-allow {
-  input.publicly_accessible == false
+deny {
+  input.publicly_accessible == true
 }
 


### PR DESCRIPTION
This fixes an issue with `FG_R00278` where we weren't accounting for the default `false` value of `aws_db_instance.publicly_accessible`.