### PR TITLE
Use top-level .terraform directory for nested remote tf modules

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -203,7 +203,7 @@ func parseFiles(
 					if str, ok := source.(string); ok {
 						childDir := TfFilePathJoin(dir, str)
 						if register := configuration.moduleRegister.getDir(str); register != nil {
-							childDir = TfFilePathJoin(dir, *register)
+							childDir = *register
 						}
 						logrus.Debugf("Loading source from %s", childDir)
 
@@ -1080,7 +1080,7 @@ func TfFilePathJoin(leading, trailing string) string {
 	} else {
 		trailing = filepath.FromSlash(trailing)
 		sep := string(filepath.Separator)
-		trailing = strings.TrimPrefix(trailing, "." + sep)
+		trailing = strings.TrimPrefix(trailing, "."+sep)
 		return strings.TrimRight(leading, sep) + sep +
 			strings.TrimLeft(trailing, sep)
 	}


### PR DESCRIPTION
Terraform downloads remote modules that are referenced by other remote modules to the top-level `.terraform` directory rather than to separate `.terraform` directories in each child. This change makes it so we look in that top-level directory instead of in each child directory.


### Example

Your top level configuration depends on a remote module `vpc` that depends another remote module `subnets`. Running `terraform init` would download those modules to:

```
.terraform/modules/vpc
.terraform/modules/subnets
```

instead of

```
.terraform/modules/vpc
.terraform/modules/vpc/.terraform/modules/subnets
```