### PR TITLE
Normalize file paths in LoadPaths

### DIFF
--- a/pkg/loader/loadpaths.go
+++ b/pkg/loader/loadpaths.go
@@ -64,6 +64,8 @@ func LoadPaths(options LoadPathsOptions) (LoadedConfigurations, error) {
 	for _, path := range options.Paths {
 		if path == "-" {
 			path = stdIn
+		} else {
+			path = filepath.Clean(path)
 		}
 		if configurations.AlreadyLoaded(path) {
 			continue


### PR DESCRIPTION
This PR resolves #167. The issue was that a lot of our code produces ['clean' paths](https://pkg.go.dev/path/filepath#Clean) and we weren't accounting for that when we check whether or not we've loaded already loaded a file. This was causing TF files to get loaded twice if the input path had a leading `./`.