### PR TITLE
Improving some TF loader warnings

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -91,18 +91,16 @@ func (t *TfDetector) DetectDirectory(i InputDirectory, opts DetectOptions) (IACC
 
 func missingRemoteModulesMessage(inputPath string, missingModules []string) string {
 	missingModulesList := strings.Join(missingModules, ", ")
-	if inputPath == "." {
-		return fmt.Sprintf(
-			"Could not load some remote submodules. "+
-				"Run 'terraform init' if you would like to include them in the evaluation: %s",
-			missingModulesList,
+	firstSentence := "Could not load some remote submodules"
+	if inputPath != "." {
+		firstSentence += fmt.Sprintf(
+			" that are used by '%s'",
+			inputPath,
 		)
 	}
-
 	return fmt.Sprintf(
-		"Could not load some remote submodules that are used by '%s'. "+
-			"Run 'terraform init' if you would like to include them in the evaluation: %s",
-		inputPath,
+		"%s. Run 'terraform init' if you would like to include them in the evaluation: %s",
+		firstSentence,
 		missingModulesList,
 	)
 }

--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -78,15 +78,33 @@ func (t *TfDetector) DetectDirectory(i InputDirectory, opts DetectOptions) (IACC
 	}
 
 	if configuration != nil && len(configuration.missingRemoteModules) > 0 {
-		logrus.Warnf(
-			"Could not load some remote submodules that are used by '%s'. "+
-				"Run 'terraform init' if you would like to include them in the evaluation: %s",
-			i.Path(),
-			strings.Join(configuration.missingRemoteModules, ", "),
+		logrus.Warn(
+			missingRemoteModulesMessage(
+				i.Path(),
+				configuration.missingRemoteModules,
+			),
 		)
 	}
 
 	return configuration, nil
+}
+
+func missingRemoteModulesMessage(inputPath string, missingModules []string) string {
+	missingModulesList := strings.Join(missingModules, ", ")
+	if inputPath == "." {
+		return fmt.Sprintf(
+			"Could not load some remote submodules. "+
+				"Run 'terraform init' if you would like to include them in the evaluation: %s",
+			missingModulesList,
+		)
+	}
+
+	return fmt.Sprintf(
+		"Could not load some remote submodules that are used by '%s'. "+
+			"Run 'terraform init' if you would like to include them in the evaluation: %s",
+		inputPath,
+		missingModulesList,
+	)
 }
 
 type HclConfiguration struct {


### PR DESCRIPTION
This change improves two TF loader warnings:

* The warnings we emit when remote submodules are missing. These currently look like:
```
WARNING Error loading submodule gcp-network: <nil>: Failed to read module directory; Module directory terraform-google-modules/network/google does not exist or cannot be read. 
WARNING Error loading submodule gcs_buckets: <nil>: Failed to read module directory; Module directory terraform-google-modules/cloud-storage/google does not exist or cannot be read.
```
  After this PR, we'll collect the missing remote modules into a single warning that mentions `terraform init`:
```
# if the warning is for your current working directory
WARNING Could not load some remote submodules. Run 'terraform init' if you would like to include them in the evaluation: terraform-google-modules/network/google, terraform-google-modules/cloud-storage/google

# or if the warning is for any other directory, the name will be part of the message
WARNING Could not load some remote submodules that are used by 'google-terraform-example'. Run 'terraform init' if you would like to include them in the evaluation: terraform-google-modules/network/google, terraform-google-modules/cloud-storage/google 
```
* Downgrading `Skipping object key of unknown type` from a warning to a debug message. There are cases where this indicates a deficiency in our loader, but it can also happen when things are working normally.