### PR TITLE
[RM-5612] Regula configuration file

### DIFF
--- a/changes/unreleased/Added-20210812-124517.yaml
+++ b/changes/unreleased/Added-20210812-124517.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: A configuration file for 'regula run'. See [the 'regula init' documentation](https://regula.dev/usage.html#init) for more details.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -15,11 +15,16 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fugue/regula/pkg/loader"
 	"github.com/fugue/regula/pkg/reporter"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/thediveo/enumflag"
 )
 
@@ -31,6 +36,9 @@ const inputTypeFlag = "input-type"
 const severityFlag = "severity"
 const formatFlag = "format"
 const traceFlag = "trace"
+const configFlag = "config"
+const noConfigFlag = "no-config"
+const inputsFlag = "inputs"
 
 const inputTypeDescriptions = `
 Input types:
@@ -61,6 +69,7 @@ Severities:
 
 func addUserOnlyFlag(cmd *cobra.Command) {
 	cmd.Flags().BoolP(userOnlyFlag, "u", false, "Disable built-in rules")
+	viper.BindPFlag(userOnlyFlag, cmd.Flags().Lookup(userOnlyFlag))
 }
 
 func addNoTestInputsFlag(cmd *cobra.Command) {
@@ -69,6 +78,7 @@ func addNoTestInputsFlag(cmd *cobra.Command) {
 
 func addIncludeFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP(includeFlag, "i", nil, "Specify additional rego files or directories to include")
+	viper.BindPFlag(includeFlag, cmd.Flags().Lookup(includeFlag))
 }
 
 func addNoIgnoreFlag(cmd *cobra.Command) {
@@ -80,6 +90,7 @@ func addInputTypeFlag(cmd *cobra.Command, inputTypes *[]loader.InputType) {
 		enumflag.NewSlice(inputTypes, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
 		inputTypeFlag, "t",
 		"Search for or assume the input type for the given paths. Can be specified multiple times.")
+	viper.BindPFlag(inputTypeFlag, cmd.Flags().Lookup(inputTypeFlag))
 }
 
 func addSeverityFlag(cmd *cobra.Command, severity *reporter.Severity) {
@@ -87,6 +98,7 @@ func addSeverityFlag(cmd *cobra.Command, severity *reporter.Severity) {
 		enumflag.New(severity, "string", reporter.SeverityIds, enumflag.EnumCaseInsensitive),
 		severityFlag, "s",
 		"Set the minimum severity that will result in a non-zero exit code.")
+	viper.BindPFlag(severityFlag, cmd.Flags().Lookup(severityFlag))
 }
 
 func addFormatFlag(cmd *cobra.Command, format *reporter.Format) {
@@ -100,10 +112,79 @@ func addTraceFlag(cmd *cobra.Command) {
 	cmd.Flags().BoolP(traceFlag, "t", false, "Enable trace output")
 }
 
+func addConfigFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP(configFlag, "c", "", "Path to .regula.yaml file. By default regula will look in the current working directory and its parents.")
+}
+
+func addNoConfigFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(noConfigFlag, false, "Do not look for or load a regula config file.")
+}
+
 func joinDescriptions(descriptions ...string) string {
 	normalizedDescriptions := make([]string, len(descriptions))
 	for i, d := range descriptions {
 		normalizedDescriptions[i] = strings.TrimSpace(d)
 	}
 	return strings.Join(normalizedDescriptions, "\n\n")
+}
+
+func loadConfigFile(configPath string) error {
+	viper.SetConfigType("yaml")
+
+	if configPath != "" {
+		viper.SetConfigFile(configPath)
+	} else {
+		viper.SetConfigName(".regula.yaml")
+		currDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		prevDir := ""
+		for currDir != prevDir {
+			// This is to avoid errors from viper if the user doesn't have permission
+			// to some parent directories.
+			if _, err := os.Stat(currDir); err != nil {
+				break
+			}
+			viper.AddConfigPath(currDir)
+			prevDir = currDir
+			currDir = filepath.Dir(currDir)
+		}
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			logrus.Debugf("Could not find configuration file: %s", err)
+			// This is only considered an error if the user specified a config file
+			if configPath != "" {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	if p := viper.ConfigFileUsed(); p != "" {
+		logrus.Infof("Using config file '%s'", p)
+	}
+
+	return nil
+}
+
+func setEnumFromConfig(cmd *cobra.Command, flagName string) error {
+	flag := cmd.Flags().Lookup(flagName)
+
+	if flag.Changed {
+		return nil
+	}
+
+	if viper.IsSet(flagName) {
+		value := strings.Join(viper.GetStringSlice(flagName), ",")
+		if err := flag.Value.Set(value); err != nil {
+			return fmt.Errorf("Invalid value for '%s' in config file: %s", flagName, err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -174,7 +174,7 @@ func loadConfigFile(configPath string) error {
 	}
 
 	if p := viper.ConfigFileUsed(); p != "" {
-		logrus.Infof("Using config file '%s'", p)
+		fmt.Fprintf(os.Stderr, "Using config file '%s'\n", p)
 	}
 
 	return nil

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,109 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/fugue/regula/pkg/loader"
+	"github.com/fugue/regula/pkg/reporter"
+	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag"
+)
+
+const userOnlyFlag = "user-only"
+const noTestInputsFlag = "no-test-inputs"
+const includeFlag = "include"
+const noIgnoreFlag = "no-ignore"
+const inputTypeFlag = "input-type"
+const severityFlag = "severity"
+const formatFlag = "format"
+const traceFlag = "trace"
+
+const inputTypeDescriptions = `
+Input types:
+    auto        Automatically determine input types (default)
+    tf-plan     Terraform plan JSON
+    cfn         CloudFormation template in YAML or JSON format
+    tf          Terraform directory or file
+`
+const formatDescriptions = `
+Output formats:
+    text    A human friendly format (default)
+    json    A JSON report containing rule results and a summary
+    table   An ASCII table of rule results
+    junit   The JUnit XML format
+    tap     The Test Anything Protocol format
+    none    Do not print any output on stdout
+`
+const severityDescriptions = `
+Severities:
+    unknown         Lowest setting. Used for rules without a severity specified (default)
+    informational
+    low
+    medium
+    high
+    critical
+    off             Never exit with a non-zero exit code.
+`
+
+func addUserOnlyFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolP(userOnlyFlag, "u", false, "Disable built-in rules")
+}
+
+func addNoTestInputsFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(noTestInputsFlag, false, "Disable loading test inputs")
+}
+
+func addIncludeFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceP(includeFlag, "i", nil, "Specify additional rego files or directories to include")
+}
+
+func addNoIgnoreFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolP(noIgnoreFlag, "n", false, "Disable use of .gitignore")
+}
+
+func addInputTypeFlag(cmd *cobra.Command, inputTypes *[]loader.InputType) {
+	cmd.Flags().VarP(
+		enumflag.NewSlice(inputTypes, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
+		inputTypeFlag, "t",
+		"Search for or assume the input type for the given paths. Can be specified multiple times.")
+}
+
+func addSeverityFlag(cmd *cobra.Command, severity *reporter.Severity) {
+	cmd.Flags().VarP(
+		enumflag.New(severity, "string", reporter.SeverityIds, enumflag.EnumCaseInsensitive),
+		severityFlag, "s",
+		"Set the minimum severity that will result in a non-zero exit code.")
+}
+
+func addFormatFlag(cmd *cobra.Command, format *reporter.Format) {
+	cmd.Flags().VarP(
+		enumflag.New(format, "string", reporter.FormatIds, enumflag.EnumCaseInsensitive),
+		formatFlag, "f",
+		"Set the output format")
+}
+
+func addTraceFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolP(traceFlag, "t", false, "Enable trace output")
+}
+
+func joinDescriptions(descriptions ...string) string {
+	normalizedDescriptions := make([]string, len(descriptions))
+	for i, d := range descriptions {
+		normalizedDescriptions[i] = strings.TrimSpace(d)
+	}
+	return strings.Join(normalizedDescriptions, "\n\n")
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -39,6 +39,7 @@ const traceFlag = "trace"
 const configFlag = "config"
 const noConfigFlag = "no-config"
 const inputsFlag = "inputs"
+const forceFlag = "force"
 
 const inputTypeDescriptions = `
 Input types:
@@ -118,6 +119,10 @@ func addConfigFlag(cmd *cobra.Command) {
 
 func addNoConfigFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool(noConfigFlag, false, "Do not look for or load a regula config file.")
+}
+
+func addForceFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolP(forceFlag, "f", false, "Overwrite configuration file without prompting for confirmation.")
 }
 
 func joinDescriptions(descriptions ...string) string {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -92,6 +92,7 @@ func addInputTypeFlag(cmd *cobra.Command, inputTypes *[]loader.InputType) {
 		inputTypeFlag, "t",
 		"Search for or assume the input type for the given paths. Can be specified multiple times.")
 	viper.BindPFlag(inputTypeFlag, cmd.Flags().Lookup(inputTypeFlag))
+	cmd.Long = joinDescriptions(cmd.Long, inputTypeDescriptions)
 }
 
 func addSeverityFlag(cmd *cobra.Command, severity *reporter.Severity) {
@@ -100,6 +101,7 @@ func addSeverityFlag(cmd *cobra.Command, severity *reporter.Severity) {
 		severityFlag, "s",
 		"Set the minimum severity that will result in a non-zero exit code.")
 	viper.BindPFlag(severityFlag, cmd.Flags().Lookup(severityFlag))
+	cmd.Long = joinDescriptions(cmd.Long, severityDescriptions)
 }
 
 func addFormatFlag(cmd *cobra.Command, format *reporter.Format) {
@@ -107,6 +109,7 @@ func addFormatFlag(cmd *cobra.Command, format *reporter.Format) {
 		enumflag.New(format, "string", reporter.FormatIds, enumflag.EnumCaseInsensitive),
 		formatFlag, "f",
 		"Set the output format")
+	cmd.Long = joinDescriptions(cmd.Long, formatDescriptions)
 }
 
 func addTraceFlag(cmd *cobra.Command) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,10 +59,10 @@ func NewInitCommand() *cobra.Command {
 			if cmd.Flags().Lookup(severityFlag).Changed {
 				// These conditions hopefully aren't possible
 				if _, ok := reporter.SeverityIds[severity]; !ok {
-					logrus.Fatalf("Invalid severity %s", severity)
+					logrus.Fatalf("Invalid severity %d", severity)
 				}
 				if len(reporter.SeverityIds[severity]) < 1 {
-					logrus.Fatalf("Could not map string value for severity %s", severity)
+					logrus.Fatalf("Could not map string value for severity %d", severity)
 				}
 				configuredSeverity := reporter.SeverityIds[severity][0]
 				v.Set(severityFlag, configuredSeverity)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewInitCommand() *cobra.Command {
-	inputTypes := []loader.InputType{}
+	inputTypes := []loader.InputType{loader.Auto}
 	severity := reporter.Unknown
 	description := "Create a new Regula configuration file in the current working directory."
 	cmd := &cobra.Command{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	_ "embed"
+	"path/filepath"
+
+	"github.com/fugue/regula/pkg/loader"
+	"github.com/fugue/regula/pkg/reporter"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func NewInitCommand() *cobra.Command {
+	inputTypes := []loader.InputType{}
+	severity := reporter.Unknown
+	description := "Create a new Regula configuration file in the current working directory."
+	cmd := &cobra.Command{
+		Use:   "init [input...]",
+		Short: description,
+		Long: joinDescriptions(
+			description,
+			inputTypeDescriptions,
+			formatDescriptions,
+			severityDescriptions),
+		Run: func(cmd *cobra.Command, paths []string) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			v.SetConfigFile(filepath.Join(".", ".regula.yaml"))
+
+			if cmd.Flags().Lookup(inputTypeFlag).Changed {
+				configuredInputTypes := []string{}
+				for _, t := range inputTypes {
+					configuredInputTypes = append(
+						configuredInputTypes,
+						loader.InputTypeIDs[t][0],
+					)
+				}
+				v.Set(inputTypeFlag, configuredInputTypes)
+			}
+
+			if cmd.Flags().Lookup(severityFlag).Changed {
+				configuredSeverity := reporter.SeverityIds[severity][0]
+				v.Set(severityFlag, configuredSeverity)
+			}
+
+			if cmd.Flags().Lookup(includeFlag).Changed {
+				configuredIncludes, err := cmd.Flags().GetStringSlice(includeFlag)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+				v.Set(includeFlag, configuredIncludes)
+			}
+
+			if cmd.Flags().Lookup(userOnlyFlag).Changed {
+				configuredUserOnly, err := cmd.Flags().GetBool(userOnlyFlag)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+				v.Set(userOnlyFlag, configuredUserOnly)
+			}
+
+			if len(paths) > 0 {
+				v.Set(inputsFlag, paths)
+			}
+
+			v.WriteConfig()
+		},
+	}
+	addIncludeFlag(cmd)
+	addUserOnlyFlag(cmd)
+	addInputTypeFlag(cmd, &inputTypes)
+	addSeverityFlag(cmd, &severity)
+
+	cmd.Flags().SetNormalizeFunc(normalizeFlag)
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(NewInitCommand())
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -57,6 +57,13 @@ func NewInitCommand() *cobra.Command {
 			}
 
 			if cmd.Flags().Lookup(severityFlag).Changed {
+				// These conditions hopefully aren't possible
+				if _, ok := reporter.SeverityIds[severity]; !ok {
+					logrus.Fatalf("Invalid severity %s", severity)
+				}
+				if len(reporter.SeverityIds[severity]) < 1 {
+					logrus.Fatalf("Could not map string value for severity %s", severity)
+				}
 				configuredSeverity := reporter.SeverityIds[severity][0]
 				v.Set(severityFlag, configuredSeverity)
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,9 +37,8 @@ func NewInitCommand() *cobra.Command {
 		Short: description,
 		Long: joinDescriptions(
 			description,
-			inputTypeDescriptions,
-			formatDescriptions,
-			severityDescriptions),
+			"Pass one or more inputs (like you would with the 'regula run' command) in order to change the default inputs for 'regula run'.",
+		),
 		Run: func(cmd *cobra.Command, paths []string) {
 			configPath := filepath.Join(".", ".regula.yaml")
 			v := viper.New()

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -29,11 +29,11 @@ func NewREPLCommand() *cobra.Command {
 		Use:   "repl [paths containing rego or test inputs]",
 		Short: "Start an interactive session for testing rules with Regula",
 		Run: func(cmd *cobra.Command, includes []string) {
-			userOnly, err := cmd.Flags().GetBool("user-only")
+			userOnly, err := cmd.Flags().GetBool(userOnlyFlag)
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			noTestInputs, err := cmd.Flags().GetBool("no-test-inputs")
+			noTestInputs, err := cmd.Flags().GetBool(noTestInputsFlag)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -51,8 +51,8 @@ func NewREPLCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP("user-only", "u", false, "Disable built-in rules")
-	cmd.Flags().Bool("no-test-inputs", false, "Disable loading test inputs")
+	addUserOnlyFlag(cmd)
+	addNoTestInputsFlag(cmd)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -37,7 +37,7 @@ func NewREPLCommand() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			ctx := context.TODO()
+			ctx := context.Background()
 			err = rego.RunREPL(&rego.RunREPLOptions{
 				Ctx:          ctx,
 				UserOnly:     userOnly,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -79,7 +79,7 @@ func NewRunCommand() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			if configDir != "" {
 				// Changing directories is the easiest and most robust way to

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,11 +39,7 @@ func NewRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run [input...]",
 		Short: "Evaluate rules against infrastructure as code with Regula.",
-		Long: joinDescriptions(
-			runDescription,
-			inputTypeDescriptions,
-			formatDescriptions,
-			severityDescriptions),
+		Long:  runDescription,
 		Run: func(cmd *cobra.Command, args []string) {
 			noConfig, err := cmd.Flags().GetBool(noConfigFlag)
 			if err != nil {
@@ -139,8 +135,8 @@ func NewRunCommand() *cobra.Command {
 	addUserOnlyFlag(cmd)
 	addNoIgnoreFlag(cmd)
 	addInputTypeFlag(cmd, &inputTypes)
-	addSeverityFlag(cmd, &severity)
 	addFormatFlag(cmd, &format)
+	addSeverityFlag(cmd, &severity)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/run.txt
+++ b/cmd/run.txt
@@ -8,26 +8,3 @@ specified files are of that input type.
 
 By default, Regula will exclude paths based on the patterns in the .gitignore file for
 a specified directory. This behavior can be disabled with the --no-ignore option.
-
-Input types:
-    auto        Automatically determine input types (default)
-    tf-plan     Terraform plan JSON
-    cfn         CloudFormation template in YAML or JSON format
-    tf          Terraform directory or file
-
-Output formats:
-    text    A human friendly format (default)
-    json    A JSON report containing rule results and a summary
-    table   An ASCII table of rule results
-    junit   The JUnit XML format
-    tap     The Test Anything Protocol format
-    none    Do not print any output on stdout
-
-Severities:
-    unknown         Lowest setting. Used for rules without a severity specified (default)
-    informational
-    low
-    medium
-    high
-    critical
-    off             Never exit with a non-zero exit code.

--- a/cmd/run.txt
+++ b/cmd/run.txt
@@ -1,10 +1,8 @@
-Evaluate rules against infrastructure-as-code contained in one or more paths. When run
-without any paths, Regula will recursively search for IaC configurations within the
-working directory. When a directory is given Regula will recursively search for IaC
-configurations within that directory. When a file is given, Regula will assume that the
-file contains an IaC configuration. If an input type is set, Regula will only search
-for configurations of that type in the specified directories and it will assume that
-specified files are of that input type.
+Evaluate rules against infrastructure-as-code contained in one or more paths.
+
+When run without any paths, Regula will recursively search for IaC configurations within
+the working directory or use the input paths specified in your .regula.yaml file if
+it exists.
 
 By default, Regula will exclude paths based on the patterns in the .gitignore file for
 a specified directory. This behavior can be disabled with the --no-ignore option.

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -21,17 +21,16 @@ import (
 	"github.com/fugue/regula/pkg/loader"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/thediveo/enumflag"
 )
 
 func NewShowCommand() *cobra.Command {
-	var inputType loader.InputType
-
+	inputTypes := []loader.InputType{loader.Auto}
+	longDescription := `Show debug information.  Currently the available items are:
+	input [file..]   Show the JSON input being passed to regula`
 	cmd := &cobra.Command{
 		Use:   "show [item]",
 		Short: "Show debug information.",
-		Long: `Show debug information.  Currently the available items are:
-  input [file..]   Show the JSON input being passed to regula`,
+		Long:  joinDescriptions(longDescription, inputTypeDescriptions),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				logrus.Fatal("Expected an item to show")
@@ -41,8 +40,8 @@ func NewShowCommand() *cobra.Command {
 			case "input":
 				paths := args[1:]
 				loadedFiles, err := loader.LoadPaths(loader.LoadPathsOptions{
-					Paths:     paths,
-					InputType: inputType,
+					Paths:      paths,
+					InputTypes: inputTypes,
 				})
 				if err != nil {
 					logrus.Fatal(err)
@@ -60,10 +59,7 @@ func NewShowCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().VarP(
-		enumflag.New(&inputType, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
-		"input-type", "t",
-		"Set the input type for the given paths")
+	addInputTypeFlag(cmd, &inputTypes)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -30,7 +30,7 @@ func NewShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show [item]",
 		Short: "Show debug information.",
-		Long:  joinDescriptions(longDescription, inputTypeDescriptions),
+		Long:  longDescription,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				logrus.Fatal("Expected an item to show")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -29,11 +29,11 @@ func NewTestCommand() *cobra.Command {
 		Use:   "test [paths containing rego or test inputs]",
 		Short: "Run OPA test with Regula.",
 		Run: func(cmd *cobra.Command, includes []string) {
-			trace, err := cmd.Flags().GetBool("trace")
+			trace, err := cmd.Flags().GetBool(traceFlag)
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			noTestInputs, err := cmd.Flags().GetBool("no-test-inputs")
+			noTestInputs, err := cmd.Flags().GetBool(noTestInputsFlag)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -49,8 +49,8 @@ func NewTestCommand() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().BoolP("trace", "t", false, "Enable trace output")
-	cmd.Flags().Bool("no-test-inputs", false, "Disable loading test inputs")
+	addTraceFlag(cmd)
+	addNoTestInputsFlag(cmd)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -37,7 +37,7 @@ func NewTestCommand() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			ctx := context.TODO()
+			ctx := context.Background()
 			err = rego.RunTest(&rego.RunTestOptions{
 				Ctx:          ctx,
 				Includes:     includes,

--- a/cmd/write_test_inputs.go
+++ b/cmd/write_test_inputs.go
@@ -22,28 +22,26 @@ import (
 	"github.com/fugue/regula/pkg/rego"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/thediveo/enumflag"
 )
 
 func NewWriteTestInputsCommand() *cobra.Command {
-	var inputType loader.InputType
+	description := "Persist dynamically-generated test inputs for use with other Rego interpreters"
+	inputTypes := []loader.InputType{loader.Auto}
 	cmd := &cobra.Command{
 		Use:   "write-test-inputs [input...]",
-		Short: "Persist dynamically-generated test inputs for use with other Rego interpreters",
+		Short: description,
+		Long:  joinDescriptions(description, inputTypeDescriptions),
 		Run: func(cmd *cobra.Command, paths []string) {
 			cb := func(r rego.RegoFile) error {
 				return os.WriteFile(r.Path(), r.Raw(), 0644)
 			}
-			if err := rego.LoadTestInputs(paths, inputType, cb); err != nil {
+			if err := rego.LoadTestInputs(paths, inputTypes, cb); err != nil {
 				logrus.Fatal(err)
 			}
 		},
 	}
 
-	cmd.Flags().VarP(
-		enumflag.New(&inputType, "string", loader.InputTypeIDs, enumflag.EnumCaseInsensitive),
-		"input-type", "t",
-		"Set the input type for the given paths")
+	addInputTypeFlag(cmd, &inputTypes)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/write_test_inputs.go
+++ b/cmd/write_test_inputs.go
@@ -30,7 +30,7 @@ func NewWriteTestInputsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "write-test-inputs [input...]",
 		Short: description,
-		Long:  joinDescriptions(description, inputTypeDescriptions),
+		Long:  description,
 		Run: func(cmd *cobra.Command, paths []string) {
 			cb := func(r rego.RegoFile) error {
 				return os.WriteFile(r.Path(), r.Raw(), 0644)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -142,3 +142,28 @@ For instance, if you have an S3 bucket that hosts a static website, you can waiv
 In contrast, if you don't want the "block public access" rule applied to *any* S3 bucket, you can disable it and Regula will ignore the rule. No rule results will be calculated, and therefore the rule won't be included in Regula's report.
 
 (You could alternatively waive the rule for all resources, in which case you'd still see a WAIVE value for each rule result in Regula's report.)
+
+## Setting defaults for regula run
+
+Regula can use an optional `.regula.yaml` configuration file to set some default options and inputs for `regula run`. The following options can be set in the configuration file:
+
+```
+  -i, --include strings     Specify additional rego files or directories to include
+  -t, --input-type string   Search for or assume the input type for the given paths. Can be specified multiple times. (default "[auto]")
+  -s, --severity string     Set the minimum severity that will result in a non-zero exit code. (default "unknown")
+  -u, --user-only           Disable built-in rules
+```
+
+To create the configuration file, run `regula init [input...] [flags]`. An easy way to setup the configuration file is to use `regula run` to figure out which options you want to set:
+
+```
+regula run --include config/waivers.rego --include our_custom_rules infra/*.yaml
+```
+
+and then replace `run` with `init`:
+
+```
+regula init --include config/waivers.rego --include our_custom_rules infra/*.yaml
+```
+
+Afterwards, you'll be able to invoke `regula run` without any options and it will use the defaults you set with `regula init`.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -167,3 +167,25 @@ regula init --include config/waivers.rego --include our_custom_rules infra/*.yam
 ```
 
 Afterwards, you'll be able to invoke `regula run` without any options and it will use the defaults you set with `regula init`.
+
+### Search path for configuration files
+
+By default, `regula run` will look for a `.regula.yaml` configuration file in your current working directory. If it doesn't find one, it will search upwards through each parent directory until it either finds a configuration file or it reaches the volume root. For example, in the working directory `/Users/jason/workspace/project`, `regula run` would look for a configuration file in the following locations in order:
+
+* `/Users/jason/workspace/project`
+* `/Users/jason/workspace`
+* `/Users/jason`
+* `/Users`
+* `/`
+
+Alternatively, you can use the `--config` option in `regula run` to point to a specific file. This is helpful if you're in a directory outside of your project, e.g.:
+
+```
+regula run --config project/.regula.yaml
+```
+
+You can also disable the configuration file feature with the `--no-config` option:
+
+```
+regula run --no-config
+```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -343,7 +343,6 @@ Global Flags:
   -v, --verbose   verbose output
 ```
 
-
 `regula init` creates a configuration file in your current working directory that you can use to set defaults for `regula run`.
 
 Similar to `git`, `regula run` will look for this configuration file in your current working directory and its parent directories.
@@ -364,11 +363,11 @@ waivers[waiver] {
 }
 ```
 
-In order for regula to match the filepath in the waiver to the your cloudformation template, you would always need
+In order for regula to match the filepath in the waiver to your cloudformation template, you would always need
 to run regula in the parent directory of `infra`. Unless, of course, you're using a regula configuration file:
 
 ```shell
-# Here I'm showing the layout of my project
+# Here I'm showing the layout of the project
 $ tree
 .
 ├── README.md
@@ -379,12 +378,12 @@ $ tree
 └── src
     └── some_files
 
-# Now I'll create a configuration file in my project's root directory and indicate that
+# Now I'll create a configuration file in the project's root directory and indicate that
 # by default, I'd like to run regula against my 'infra' directory.
 $ regula init --include config/waivers.rego infra
 
-# And now I can run regula from anywhere within my project and it will apply the
-# defaults from my configuration file and correctly apply the waiver.
+# And now I can run regula from anywhere within the project and it will apply the
+# defaults from the configuration file and correctly apply the waiver.
 $ cd src
 $ regula run
 INFO Using config file '/Users/jason/workspace/my-project/.regula.yaml' 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -345,7 +345,7 @@ Global Flags:
 
 `regula init` creates a configuration file in your current working directory that you can use to set defaults for `regula run`.
 
-Similar to `git`, `regula run` will look for this configuration file in your current working directory and its parent directories.
+Similar to `git`, `regula run` will look for this configuration file in your current working directory, followed by its parent directories.
 
 Besides setting defaults for `regula run`, the configuration file also helps regula calculate relative paths for your inputs. As an
 example of why this is useful, say you've got this `waivers.rego` file that waives the "S3 buckets should have all `block public access` options enabled"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -14,6 +14,7 @@ Usage:
 
 Available Commands:
   help              Help about any command
+  init              Create a new Regula configuration file in the current working directory.
   repl              Start an interactive session for testing rules with Regula
   run               Evaluate rules against infrastructure as code with Regula.
   show              Show debug information.
@@ -37,13 +38,18 @@ Usage:
   regula run [input...] [flags]
 
 Flags:
-  -f, --format format           Set the output format (default text)
-  -h, --help                    help for run
-  -i, --include strings         Specify additional rego files or directories to include
-  -t, --input-type input-type   Set the input type for the given paths (default auto)
-  -n, --no-ignore               Disable use of .gitignore
-  -s, --severity severity       Set the minimum severity that will result in a non-zero exit code. (default unknown)
-  -u, --user-only               Disable built-in rules
+  -c, --config string       Path to .regula.yaml file. By default regula will look in the current working directory and its parents.
+  -f, --format string       Set the output format (default "text")
+  -h, --help                help for run
+  -i, --include strings     Specify additional rego files or directories to include
+  -t, --input-type string   Search for or assume the input type for the given paths. Can be specified multiple times. (default "[auto]")
+      --no-config           Do not look for or load a regula config file.
+  -n, --no-ignore           Disable use of .gitignore
+  -s, --severity string     Set the minimum severity that will result in a non-zero exit code. (default "unknown")
+  -u, --user-only           Disable built-in rules
+
+Global Flags:
+  -v, --verbose   verbose output
 ```
 
 ### Input
@@ -314,6 +320,77 @@ Use the `--f | --format FORMAT` flag to specify the output format:
     ```
 
 For more about Regula's output, see [Report Output](report.md).
+
+## init
+
+```
+Create a new Regula configuration file in the current working directory.
+
+Pass one or more inputs (like you would with the 'regula run' command) in order to change the default inputs for 'regula run'.
+
+Usage:
+  regula init [input...] [flags]
+
+Flags:
+  -f, --force               Overwrite configuration file without prompting for confirmation.
+  -h, --help                help for init
+  -i, --include strings     Specify additional rego files or directories to include
+  -t, --input-type string   Search for or assume the input type for the given paths. Can be specified multiple times. (default "[auto]")
+  -s, --severity string     Set the minimum severity that will result in a non-zero exit code. (default "unknown")
+  -u, --user-only           Disable built-in rules
+
+Global Flags:
+  -v, --verbose   verbose output
+```
+
+
+`regula init` creates a configuration file in your current working directory that you can use to set defaults for `regula run`.
+
+Similar to `git`, `regula run` will look for this configuration file in your current working directory and its parent directories.
+
+Besides setting defaults for `regula run`, the configuration file also helps regula calculate relative paths for your inputs. As an
+example of why this is useful, say you've got this `waivers.rego` file that waives the "S3 buckets should have all `block public access` options enabled"
+rule on a bucket hosts your company's website:
+
+```ruby
+package fugue.regula.config
+
+waivers[waiver] {
+  waiver := {
+    "filepath": "infra/cloudformation.yaml",
+    "resource_id": "WebsiteBucket",
+    "rule_id": "FG_R00031",
+  }
+}
+```
+
+In order for regula to match the filepath in the waiver to the your cloudformation template, you would always need
+to run regula in the parent directory of `infra`. Unless, of course, you're using a regula configuration file:
+
+```shell
+# Here I'm showing the layout of my project
+$ tree
+.
+├── README.md
+├── config
+│   └── waivers.rego
+├── infra
+│   └── cloudformation.yaml
+└── src
+    └── some_files
+
+# Now I'll create a configuration file in my project's root directory and indicate that
+# by default, I'd like to run regula against my 'infra' directory.
+$ regula init --include config/waivers.rego infra
+
+# And now I can run regula from anywhere within my project and it will apply the
+# defaults from my configuration file and correctly apply the waiver.
+$ cd src
+$ regula run
+INFO Using config file '/Users/jason/workspace/my-project/.regula.yaml' 
+
+No problems found. Keep up the good work.
+```
 
 ## repl
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -391,6 +391,26 @@ INFO Using config file '/Users/jason/workspace/my-project/.regula.yaml'
 No problems found. Keep up the good work.
 ```
 
+### Examples
+
+Disable all built-in rules and add custom rules from a `rules` directory:
+
+```
+regula init --user-only --include rules
+```
+
+Configure some specific inputs and the severity flag:
+
+```
+regula init --severity high src/*/cloudformation.yaml
+```
+
+Configure which input types Regula should search for:
+
+```
+regula init --input-type tf --input-type cfn
+```
+
 ## repl
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform v0.15.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/hashicorp/terraform-provider-google v1.20.0 // indirect
+	github.com/manifoldco/promptui v0.8.0
 	github.com/open-policy-agent/opa v0.28.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.0
 	github.com/terraform-providers/terraform-provider-google v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
@@ -241,6 +242,7 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 h1:R+19WKQClnfMXS60cP5BmMe1wjZ4u0evY2p2Ar0ZTXo=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
@@ -410,6 +412,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.10.1-0.20200424014253-c3bfe50899e5/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -565,6 +568,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -610,6 +614,7 @@ github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
@@ -734,6 +739,7 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d h1:zapSxdmZYY6vJWXFKLQ+MkI+agc+HQyfrCGowDSHiKs=
@@ -811,8 +817,10 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -823,6 +831,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -830,6 +839,7 @@ github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -839,6 +849,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -852,6 +863,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
@@ -1346,6 +1358,7 @@ gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,11 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -570,6 +573,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
@@ -610,6 +615,8 @@ github.com/likexian/simplejson-go v0.0.0-20190409170913-40473a74d76d/go.mod h1:T
 github.com/likexian/simplejson-go v0.0.0-20190419151922-c1f9f0b4f084/go.mod h1:U4O1vIJvIKwbMZKUJ62lppfdvkCdVd2nfMimHK81eec=
 github.com/likexian/simplejson-go v0.0.0-20190502021454-d8787b4bfa0b/go.mod h1:3BWwtmKP9cXWwYCr5bkoVDEfLywacOv0s06OBEDpyt8=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -617,6 +624,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9kyRqQo=
+github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88/go.mod h1:a2HXwefeat3evJHxFXSayvRHpYEPJYtErl4uIzfaUqY=

--- a/pkg/loader/auto.go
+++ b/pkg/loader/auto.go
@@ -29,6 +29,10 @@ func (a *AutoDetector) DetectFile(i InputFile, opts DetectOptions) (IACConfigura
 	return nil, nil
 }
 
+func (a *AutoDetector) InputType() InputType {
+	return Auto
+}
+
 func NewAutoDetector(detectors ...ConfigurationDetector) *AutoDetector {
 	return &AutoDetector{
 		detectors: detectors,

--- a/pkg/loader/auto.go
+++ b/pkg/loader/auto.go
@@ -29,10 +29,6 @@ func (a *AutoDetector) DetectFile(i InputFile, opts DetectOptions) (IACConfigura
 	return nil, nil
 }
 
-func (a *AutoDetector) InputType() InputType {
-	return Auto
-}
-
 func NewAutoDetector(detectors ...ConfigurationDetector) *AutoDetector {
 	return &AutoDetector{
 		detectors: detectors,

--- a/pkg/loader/base.go
+++ b/pkg/loader/base.go
@@ -114,7 +114,7 @@ type Location struct {
 //
 // These are stored as a call stack, with the most specific location in the
 // first position, and the "root of the call stack" at the last position.
-type LocationStack = []Location;
+type LocationStack = []Location
 
 func (l Location) String() string {
 	return fmt.Sprintf("%s:%d:%d", l.Path, l.Line, l.Col)

--- a/pkg/loader/loadpaths_test.go
+++ b/pkg/loader/loadpaths_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestLoadPathsDirAuto(t *testing.T) {
 	loadedConfigs, err := loader.LoadPaths(loader.LoadPathsOptions{
-		Paths:     []string{"test_inputs/data"},
-		InputType: loader.Auto,
+		Paths:      []string{"test_inputs/data"},
+		InputTypes: []loader.InputType{loader.Auto},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, loadedConfigs)
@@ -25,7 +25,7 @@ func TestLoadPathsFiles(t *testing.T) {
 			"test_inputs/data/cfn.yaml",
 			"test_inputs/data/tfplan.0.15.json",
 		},
-		InputType: loader.Auto,
+		InputTypes: []loader.InputType{loader.Auto},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, loadedConfigs)
@@ -36,8 +36,8 @@ func TestLoadPathsFiles(t *testing.T) {
 
 func TestLoadPathsDirWithType(t *testing.T) {
 	loadedConfigs, err := loader.LoadPaths(loader.LoadPathsOptions{
-		Paths:     []string{"test_inputs/data"},
-		InputType: loader.TfPlan,
+		Paths:      []string{"test_inputs/data"},
+		InputTypes: []loader.InputType{loader.TfPlan},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, loadedConfigs)

--- a/pkg/loader/tfplan.go
+++ b/pkg/loader/tfplan.go
@@ -46,7 +46,7 @@ func (t *TfPlanDetector) DetectFile(i InputFile, opts DetectOptions) (IACConfigu
 	}, nil
 }
 
-func (c *TfPlanDetector) DetectDirectory(i InputDirectory, opts DetectOptions) (IACConfiguration, error) {
+func (t *TfPlanDetector) DetectDirectory(i InputDirectory, opts DetectOptions) (IACConfiguration, error) {
 	return nil, nil
 }
 

--- a/pkg/rego/builtin.go
+++ b/pkg/rego/builtin.go
@@ -51,7 +51,6 @@ func regulaLoad(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 
 	return loadToAstTerm(loader.LoadPathsOptions{
 		Paths:       []string{path},
-		InputType:   loader.Auto,
 		NoGitIgnore: false,
 	})
 }
@@ -75,7 +74,7 @@ func regulaLoadType(ctx rego.BuiltinContext, a *ast.Term, b *ast.Term) (*ast.Ter
 
 	return loadToAstTerm(loader.LoadPathsOptions{
 		Paths:       []string{path},
-		InputType:   inputType,
+		InputTypes:  []loader.InputType{inputType},
 		NoGitIgnore: false,
 	})
 }

--- a/pkg/rego/load.go
+++ b/pkg/rego/load.go
@@ -127,7 +127,7 @@ func LoadRegula(userOnly bool, cb func(r RegoFile) error) error {
 	return nil
 }
 
-func LoadTestInputs(paths []string, inputType loader.InputType, cb func(r RegoFile) error) error {
+func LoadTestInputs(paths []string, inputTypes []loader.InputType, cb func(r RegoFile) error) error {
 	filteredPaths := []string{}
 	for _, p := range paths {
 		if !opaExts[filepath.Ext(p)] {
@@ -140,7 +140,7 @@ func LoadTestInputs(paths []string, inputType loader.InputType, cb func(r RegoFi
 	configs, err := loader.LoadPaths(loader.LoadPathsOptions{
 		Paths:      filteredPaths,
 		IgnoreDirs: true,
-		InputType:  inputType,
+		InputTypes: inputTypes,
 	})
 	if err != nil {
 		// Ignore if we can't load any configs

--- a/pkg/rego/rego_test.go
+++ b/pkg/rego/rego_test.go
@@ -37,7 +37,7 @@ func runRegoTest(t *testing.T, userOnly bool, includes []string) {
 	if err := rego.LoadOSFiles(includes, cb); err != nil {
 		assert.Fail(t, "Failed to load regula tests", err)
 	}
-	if err := rego.LoadTestInputs(includes, loader.Auto, cb); err != nil {
+	if err := rego.LoadTestInputs(includes, []loader.InputType{loader.Auto}, cb); err != nil {
 		assert.Fail(t, "Failed to load test inputs", err)
 	}
 	ctx := context.Background()

--- a/pkg/rego/runrepl.go
+++ b/pkg/rego/runrepl.go
@@ -64,7 +64,7 @@ func initStore(ctx context.Context, userOnly bool, includes []string, noTestInpu
 		return nil, err
 	}
 	if !noTestInputs {
-		if err := LoadTestInputs(includes, loader.Auto, cb); err != nil {
+		if err := LoadTestInputs(includes, []loader.InputType{loader.Auto}, cb); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/rego/runtest.go
+++ b/pkg/rego/runtest.go
@@ -35,7 +35,7 @@ func RunTest(options *RunTestOptions) error {
 		return err
 	}
 	if !options.NoTestInputs {
-		if err := LoadTestInputs(options.Includes, loader.Auto, cb); err != nil {
+		if err := LoadTestInputs(options.Includes, []loader.InputType{loader.Auto}, cb); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR adds a configuration file feature to regula. The configuration file is created through `regula init` command and currently only applies to the `regula run` command.

Because it's only possible to use one configuration file at a time, I've also made it so that `--input-type` can be specified multiple times. I also refactored some of the `cmd` code around flags in order to cut down on repeated descriptions and parsing code.