### PR TITLE
[RM-5845] Remove out-of-date NIST mappings

### DIFF
--- a/rego/rules/tf/aws/cloudfront/distribution_https.rego
+++ b/rego/rules/tf/aws/cloudfront/distribution_https.rego
@@ -19,12 +19,6 @@ __rego__metadoc__ := {
   "title": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https",
   "description": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https. CloudFront connections should be encrypted during transmission over networks that can be accessed by malicious individuals. A CloudFront distribution should only use HTTPS or Redirect HTTP to HTTPS for communication between viewers and CloudFront.",
   "custom": {
-    "controls": {
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-17(2)",
-        "NIST-800-53_vRev4_SC-8"
-      ]
-    },
     "severity": "Medium"
   }
 }

--- a/rego/rules/tf/aws/cloudtrail/log_file_validation.rego
+++ b/rego/rules/tf/aws/cloudtrail/log_file_validation.rego
@@ -24,10 +24,6 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.2"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-2g",
-        "NIST-800-53_vRev4_AC-6(9)"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/ebs/volume_encrypted.rego
+++ b/rego/rules/tf/aws/ebs/volume_encrypted.rego
@@ -21,9 +21,6 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_2.2.1"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_SC-13"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/iam/user_attached_policy.rego
+++ b/rego/rules/tf/aws/iam/user_attached_policy.rego
@@ -26,9 +26,6 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_1.15"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-2(7)(b)"
       ]
     },
     "severity": "Low"

--- a/rego/rules/tf/aws/s3/bucket_sse.rego
+++ b/rego/rules/tf/aws/s3/bucket_sse.rego
@@ -22,9 +22,6 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_2.1.1"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_SC-13"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/security_group/ingress_anywhere_rdp.rego
+++ b/rego/rules/tf/aws/security_group/ingress_anywhere_rdp.rego
@@ -26,10 +26,6 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_5.2"
-      ],
-      "NIST": [
-        "NIST-800-53_vRev4_AC-4",
-        "NIST-800-53_vRev4_AC-17(3)"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/security_group/ingress_anywhere_ssh.rego
+++ b/rego/rules/tf/aws/security_group/ingress_anywhere_ssh.rego
@@ -26,10 +26,6 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_5.2"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-4",
-        "NIST-800-53_vRev4_AC-17(3)"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/vpc/flow_log.rego
+++ b/rego/rules/tf/aws/vpc/flow_log.rego
@@ -26,11 +26,6 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.9"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-4",
-        "NIST-800-53_vRev4_AC-7a",
-        "NIST-800-53_vRev4_AC-4a.2"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/azurerm/network/security_group_no_inbound_22.rego
+++ b/rego/rules/tf/azurerm/network/security_group_no_inbound_22.rego
@@ -27,11 +27,6 @@ __rego__metadoc__ := {
       ],
       "CIS-Azure_v1.3.0": [
         "CIS-Azure_v1.3.0_6.2"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_AC-4",
-        "NIST-800-53_vRev4_SC-7a.",
-        "NIST-800-53_vRev4_SI-4a.2."
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/azurerm/sql/firewall_no_inbound_all.rego
+++ b/rego/rules/tf/azurerm/sql/firewall_no_inbound_all.rego
@@ -24,9 +24,6 @@ __rego__metadoc__ := {
       ],
       "CIS-Azure_v1.3.0": [
         "CIS-Azure_v1.3.0_6.3"
-      ],
-      "NIST-800-53_vRev4": [
-        "NIST-800-53_vRev4_SC-7(5)"
       ]
     },
     "severity": "High"


### PR DESCRIPTION
These control mappings are out-of-sync with our main product and we are no longer maintaining them. We are only maintaining the CIS mappings in this repository.