### PR TITLE
[RM-5823] Fix type mismatch when constructing cty value

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -1091,15 +1091,11 @@ func makeValue(val interface{}) cty.Value {
 	case int64:
 		return cty.NumberIntVal(v)
 	case []interface{}:
-		if len(v) == 0 {
-			return cty.ListValEmpty(cty.DynamicPseudoType)
-		} else {
-			arr := make([]cty.Value, len(v))
-			for i, x := range v {
-				arr[i] = makeValue(x)
-			}
-			return cty.ListVal(arr)
+		arr := make([]cty.Value, len(v))
+		for i, x := range v {
+			arr[i] = makeValue(x)
 		}
+		return cty.TupleVal(arr)
 	case map[string]interface{}:
 		if len(v) == 0 {
 			return cty.EmptyObjectVal

--- a/pkg/loader/tf_test/nested-vars-rm5823.json
+++ b/pkg/loader/tf_test/nested-vars-rm5823.json
@@ -1,0 +1,40 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_network_acl.main": {
+        "_filepath": "tf_test/nested-vars-rm5823/main.tf",
+        "_provider": "aws",
+        "_type": "aws_network_acl",
+        "egress": [
+          {
+            "action": "allow",
+            "from_port": "0",
+            "ipv6_cidr_block": "::/0",
+            "protocol": "-1",
+            "rule_no": "101",
+            "to_port": "0"
+          },
+          {
+            "action": "allow",
+            "cidr_block": "0.0.0.0/0",
+            "from_port": "0",
+            "protocol": "-1",
+            "rule_no": "100",
+            "to_port": "0"
+          }
+        ],
+        "id": "aws_network_acl.main",
+        "vpc_id": "aws_vpc.main"
+      },
+      "aws_vpc.main": {
+        "_filepath": "tf_test/nested-vars-rm5823/main.tf",
+        "_provider": "aws",
+        "_type": "aws_vpc",
+        "cidr_block": "10.0.0.0/24",
+        "id": "aws_vpc.main"
+      }
+    }
+  },
+  "filepath": "tf_test/nested-vars-rm5823"
+}

--- a/pkg/loader/tf_test/nested-vars-rm5823/main.tf
+++ b/pkg/loader/tf_test/nested-vars-rm5823/main.tf
@@ -1,0 +1,36 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "default_network_acl_egress" {
+  description = "List of maps of egress rules to set on the Default Network ACL"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_no    = 100
+      action     = "allow"
+      from_port  = 0
+      to_port    = 0
+      protocol   = "-1"
+      cidr_block = "0.0.0.0/0"
+    },
+    {
+      rule_no         = 101
+      action          = "allow"
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      ipv6_cidr_block = "::/0"
+    },
+  ]
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/24"
+}
+
+resource "aws_network_acl" "main" {
+  vpc_id = aws_vpc.main.id
+  egress = reverse(var.default_network_acl_egress)
+}


### PR DESCRIPTION
The TF loader uses two representations of the document:

1.  The native Go fashion, e.g. `[]interface{}` for arrays,
    `map[string]interface{}` for objects, etc.
2.  A more typed version, using the `cty` library.

When dealing with variables, we must sometimes convert from (1) to (2). `cty`
requires lists to be homogenous.  This is usually not a problem since the types
in the schemas enforce this; however, in some cases we don't have these schemas,
and this list ends up looking heterogenous:

    [
        {
          rule_no    = 100
          cidr_block = "0.0.0.0/0"
        },
        {
          rule_no         = 101
          ipv6_cidr_block = "::/0"
        },
    ]

We work around this by using a tuple instead of a list which allows for
different types.