### PR TITLE
[RM-5856] Package to modify rego metadoc

### DIFF
--- a/pkg/metadoc/metadoc.go
+++ b/pkg/metadoc/metadoc.go
@@ -1,0 +1,184 @@
+package metadoc
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+// Utility to modify metadata of rego files.
+//
+// You can load this using `RegoMetaFromPath` or `RegoMetaFromString`.
+//
+// Then, you read and/or modify the public fields of this structure.  When
+// you're done, you can turn it into a string again using `String()` and pass
+// it to OPA or write it to disk.
+type RegoMeta struct {
+	lines []string // Lines in the file
+
+	PackageName     string // Optional package name
+	packageNameLine int    // Original package name line, -1 if not present.
+
+	metadocStartLine int                    // Start of metadoc, -1 if not present
+	metadocEndLine   int                    // End of metadoc, -1 if not present
+	metadoc          map[string]interface{} // Dynamic metadoc
+
+	Id          string
+	Title       string
+	Description string
+	Severity    string
+	Controls    map[string][]string
+}
+
+func RegoMetaFromPath(path string) (*RegoMeta, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return RegoMetaFromString(string(content))
+}
+
+type metadocCustom struct {
+	Severity string              `json:"severity"`
+	Controls map[string][]string `json:"controls"`
+}
+
+type metadoc struct {
+	Id          string         `json:"id"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	Custom      *metadocCustom `json:"custom,omitempty"`
+}
+
+func RegoMetaFromString(str string) (*RegoMeta, error) {
+	// Split on lines.
+	rego := RegoMeta{}
+	rego.lines = regexp.MustCompile(`(\r\n)|\n`).Split(str, -1)
+
+	// Run through lines to parse some bits.
+	rego.packageNameLine = -1
+	rego.metadocStartLine = -1
+	rego.metadocEndLine = -1
+	for i := 0; i < len(rego.lines); i++ {
+		line := rego.lines[i]
+		words := strings.Fields(line)
+		if len(words) == 2 && words[0] == "package" {
+			rego.PackageName = words[1]
+			rego.packageNameLine = i
+		}
+
+		if len(words) == 3 && words[0] == "__rego__metadoc__" &&
+			(words[1] == ":=" || words[1] == "=") &&
+			words[2] == "{" {
+			rego.metadocStartLine = i
+			for i+1 < len(rego.lines) && rego.metadocEndLine < 0 {
+				i += 1
+				if rego.lines[i] == "}" {
+					rego.metadocEndLine = i
+				}
+			}
+		}
+	}
+
+	// Parse metadoc if appropriate.
+	if rego.metadocStartLine >= 0 {
+		metadoc := metadoc{}
+		lines := []string{"{"}
+		lines = append(lines, rego.lines[rego.metadocStartLine+1:rego.metadocEndLine+1]...)
+		jsonBytes := []byte(strings.Join(lines, "\n"))
+		if err := json.Unmarshal(jsonBytes, &metadoc); err != nil {
+			return nil, err
+		}
+
+		rego.metadoc = map[string]interface{}{}
+		if err := json.Unmarshal(jsonBytes, &rego.metadoc); err != nil {
+			return nil, err
+		}
+
+		rego.Id = metadoc.Id
+		rego.Title = metadoc.Title
+		rego.Description = metadoc.Description
+		if metadoc.Custom != nil {
+			rego.Controls = metadoc.Custom.Controls
+			rego.Severity = metadoc.Custom.Severity
+		}
+	}
+
+	return &rego, nil
+}
+
+func (rego *RegoMeta) String() string {
+	// Sync metadoc
+	if rego.metadoc == nil {
+		rego.metadoc = map[string]interface{}{}
+	}
+	if rego.Id == "" {
+		delete(rego.metadoc, "id")
+	} else {
+		rego.metadoc["id"] = rego.Id
+	}
+	if rego.Title == "" {
+		delete(rego.metadoc, "title")
+	} else {
+		rego.metadoc["title"] = rego.Title
+	}
+	if rego.Description == "" {
+		delete(rego.metadoc, "description")
+	} else {
+		rego.metadoc["description"] = rego.Description
+	}
+	custom := map[string]interface{}{}
+	if c, ok := rego.metadoc["custom"]; ok {
+		custom, _ = c.(map[string]interface{})
+	}
+	if rego.Severity == "" {
+		delete(custom, "severity")
+	} else {
+		custom["severity"] = rego.Severity
+	}
+	if len(rego.Controls) == 0 {
+		delete(custom, "controls")
+	} else {
+		custom["controls"] = rego.Controls
+	}
+	if len(custom) == 0 {
+		delete(custom, "custom")
+	} else {
+		rego.metadoc["custom"] = custom
+	}
+
+	// Render metadoc
+	haveMetadoc := len(rego.metadoc) > 0
+	metadocString := "__rego__metadoc__ := {\n}"
+	if metadocBytes, err := json.MarshalIndent(rego.metadoc, "", "  "); err == nil {
+		metadocString = "__rego__metadoc__ := " + string(metadocBytes)
+	}
+
+	lines := []string{}
+	if rego.packageNameLine < 0 && rego.PackageName != "" {
+		lines = append(lines, "package "+rego.PackageName)
+		if rego.metadocStartLine < 0 && haveMetadoc {
+			lines = append(lines, "", metadocString, "")
+		}
+	}
+
+	for i := 0; i < len(rego.lines); i++ {
+		if i == rego.packageNameLine {
+			if rego.PackageName != "" {
+				lines = append(lines, "package "+rego.PackageName)
+			}
+			if rego.metadocStartLine < 0 && haveMetadoc {
+				lines = append(lines, "", metadocString)
+			}
+		} else if i == rego.metadocStartLine {
+			lines = append(lines, metadocString)
+			i = rego.metadocEndLine
+		} else {
+			lines = append(lines, rego.lines[i])
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/metadoc/metadoc_test.go
+++ b/pkg/metadoc/metadoc_test.go
@@ -1,0 +1,226 @@
+ackage metadoc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_metadoc(t *testing.T) {
+	type Test struct {
+		input    string
+		run      func(*RegoMeta)
+		expected string
+	}
+
+	tests := []Test{
+		{
+			// Set package name
+			input: `
+package foo.bar
+
+default allow = false
+`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "foo.bar", rego.PackageName)
+				rego.PackageName = "bar.qux"
+			},
+			expected: `
+package bar.qux
+
+default allow = false
+`,
+		},
+		{
+			// Insert missing package name
+			input: `
+default allow = false
+`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "", rego.PackageName)
+				rego.PackageName = "bar.qux"
+			},
+			expected: `package bar.qux
+
+default allow = false
+`,
+		},
+		{
+			// Metadoc update
+			input: `
+# Copyright 2020 Fugue, Inc.
+package rules.tf_aws_ebs_volume_encrypted
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.2.1"
+      ],
+      "NIST-800-53_vRev4": [
+        "NIST-800-53_vRev4_SC-13"
+      ]
+    },
+    "severity": "High"
+  },
+  "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
+  "id": "FG_R00016",
+  "title": "EBS volume encryption should be enabled"
+}
+
+resource_type = "aws_ebs_volume"
+
+default allow = false
+
+allow {
+  input.encrypted == true
+}
+`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "rules.tf_aws_ebs_volume_encrypted", rego.PackageName)
+				assert.Equal(t, "FG_R00016", rego.Id)
+				assert.Equal(t, "EBS volume encryption should be enabled", rego.Title)
+				assert.Equal(t, "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.", rego.Description)
+				assert.Equal(t, "High", rego.Severity)
+				assert.Equal(t,
+					map[string][]string{
+						"CIS-AWS_v1.3.0":    {"CIS-AWS_v1.3.0_2.2.1"},
+						"NIST-800-53_vRev4": {"NIST-800-53_vRev4_SC-13"},
+					},
+					rego.Controls)
+
+				rego.Description = "Updated description"
+				rego.Severity = "Low"
+				delete(rego.Controls, "CIS-AWS_v1.3.0")
+			},
+			expected: `
+# Copyright 2020 Fugue, Inc.
+package rules.tf_aws_ebs_volume_encrypted
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "NIST-800-53_vRev4": [
+        "NIST-800-53_vRev4_SC-13"
+      ]
+    },
+    "severity": "Low"
+  },
+  "description": "Updated description",
+  "id": "FG_R00016",
+  "title": "EBS volume encryption should be enabled"
+}
+
+resource_type = "aws_ebs_volume"
+
+default allow = false
+
+allow {
+  input.encrypted == true
+}
+`,
+		},
+		{
+			// Metadoc insert
+			input: `
+# Copyright 2020 Fugue, Inc.
+package rules.tf_aws_ebs_volume_encrypted
+
+resource_type = "aws_ebs_volume"
+default allow = false
+allow {
+  input.encrypted == true
+}
+`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "rules.tf_aws_ebs_volume_encrypted", rego.PackageName)
+				assert.Equal(t, "", rego.Id)
+				assert.Equal(t, "", rego.Title)
+				assert.Equal(t, "", rego.Description)
+				assert.Equal(t, "", rego.Severity)
+				assert.Empty(t, rego.Controls)
+
+				rego.Description = "Updated description"
+				rego.Severity = "Low"
+			},
+			expected: `
+# Copyright 2020 Fugue, Inc.
+package rules.tf_aws_ebs_volume_encrypted
+
+__rego__metadoc__ := {
+  "custom": {
+    "severity": "Low"
+  },
+  "description": "Updated description"
+}
+
+resource_type = "aws_ebs_volume"
+default allow = false
+allow {
+  input.encrypted == true
+}
+`,
+		},
+		{
+			// Metadoc + package name insert
+			input: `allow { input.encrypted == true }`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "", rego.PackageName)
+
+				rego.PackageName = "foo.bar"
+				rego.Controls = map[string][]string{
+					"CIS-AWS_v1.3.0": {"CIS-AWS_v1.3.0_2.2.1"},
+				}
+			},
+			expected: `package foo.bar
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.2.1"
+      ]
+    }
+  }
+}
+
+allow { input.encrypted == true }`,
+		},
+        {
+			// Preserve unknown attributes
+			input: `
+__rego__metadoc__ := {
+  "badness": 1000,
+  "custom": {
+    "rating": "F"
+  }
+}
+
+deny { true }`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "", rego.PackageName)
+
+				rego.Severity = "High"
+			},
+			expected: `
+__rego__metadoc__ := {
+  "badness": 1000,
+  "custom": {
+    "rating": "F",
+    "severity": "High"
+  }
+}
+
+deny { true }`,
+		},
+	}
+
+	for _, test := range tests {
+		rego, err := RegoMetaFromString(test.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		test.run(rego)
+		assert.Equal(t, test.expected, rego.String())
+	}
+}

--- a/pkg/metadoc/metadoc_test.go
+++ b/pkg/metadoc/metadoc_test.go
@@ -1,4 +1,4 @@
-ackage metadoc
+package metadoc
 
 import (
 	"testing"
@@ -33,14 +33,13 @@ default allow = false
 		},
 		{
 			// Insert missing package name
-			input: `
-default allow = false
+			input: `default allow = false
 `,
 			run: func(rego *RegoMeta) {
 				assert.Equal(t, "", rego.PackageName)
-				rego.PackageName = "bar.qux"
+				rego.PackageName = "bar.dux"
 			},
-			expected: `package bar.qux
+			expected: `package bar.dux
 
 default allow = false
 `,
@@ -111,7 +110,7 @@ __rego__metadoc__ := {
   "title": "EBS volume encryption should be enabled"
 }
 
-resource_type = "aws_ebs_volume"
+resource_type := "aws_ebs_volume"
 
 default allow = false
 
@@ -154,7 +153,7 @@ __rego__metadoc__ := {
   "description": "Updated description"
 }
 
-resource_type = "aws_ebs_volume"
+resource_type := "aws_ebs_volume"
 default allow = false
 allow {
   input.encrypted == true
@@ -186,7 +185,7 @@ __rego__metadoc__ := {
 
 allow { input.encrypted == true }`,
 		},
-        {
+		{
 			// Preserve unknown attributes
 			input: `
 __rego__metadoc__ := {
@@ -212,6 +211,26 @@ __rego__metadoc__ := {
 }
 
 deny { true }`,
+		},
+		{
+			// Read resource type, modify it and set input type
+			input: `package foo.bar
+
+deny { input.age <= 21 }
+
+resource_type = "MULTIPLE"`,
+			run: func(rego *RegoMeta) {
+				assert.Equal(t, "MULTIPLE", rego.ResourceType)
+				rego.ResourceType = "aws_s3_bucket"
+				rego.InputType = "tf"
+			},
+			expected: `package foo.bar
+
+input_type := "tf"
+
+deny { input.age <= 21 }
+
+resource_type := "aws_s3_bucket"`,
 		},
 	}
 


### PR DESCRIPTION
This adds a package that allows you to load a rego file (with metadata) as a Go structure.  You can then read & edit the metadata just by setting the fields, and write it out again.