### PR TITLE
[RM-5895] Skip .terraform directory for tf configs

### DIFF
--- a/pkg/loader/base.go
+++ b/pkg/loader/base.go
@@ -144,9 +144,13 @@ type InputPath interface {
 	Name() string
 }
 
+// WalkFunc is a callback that's invoked on each descendent of an InputDirectory. It
+// returns a boolean that, when true, indicates that i.Walk() should not be called.
+type WalkFunc func(i InputPath) (skip bool, err error)
+
 type InputDirectory interface {
 	InputPath
-	Walk(w func(i InputPath) error) error
+	Walk(w WalkFunc) error
 	Children() []InputPath
 }
 

--- a/pkg/loader/input.go
+++ b/pkg/loader/input.go
@@ -30,12 +30,15 @@ func (d *directory) Name() string {
 	return d.name
 }
 
-func (d *directory) Walk(w func(i InputPath) error) error {
+func (d *directory) Walk(w WalkFunc) error {
 	for _, c := range d.children {
-		if err := w(c); err != nil {
+		skip, err := w(c)
+		if err != nil {
 			return err
 		}
-
+		if skip {
+			continue
+		}
 		if dir, ok := c.(InputDirectory); ok {
 			if err := dir.Walk(w); err != nil {
 				return err

--- a/pkg/loader/loadpaths.go
+++ b/pkg/loader/loadpaths.go
@@ -56,9 +56,10 @@ func LoadPaths(options LoadPathsOptions) (LoadedConfigurations, error) {
 	if err != nil {
 		return nil, err
 	}
-	walkFunc := func(i InputPath) error {
+	walkFunc := func(i InputPath) (skip bool, err error) {
 		if configurations.AlreadyLoaded(i.Path()) {
-			return nil
+			skip = true
+			return
 		}
 		// Ignore errors when we're recursing
 		loader, _ := i.DetectType(detector, DetectOptions{
@@ -68,7 +69,7 @@ func LoadPaths(options LoadPathsOptions) (LoadedConfigurations, error) {
 		if loader != nil {
 			configurations.AddConfiguration(i.Path(), loader)
 		}
-		return nil
+		return
 	}
 	gitRepoFinder := git.NewRepoFinder(options.Paths)
 	for _, path := range options.Paths {

--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -318,7 +318,7 @@ func (c0 *HclConfiguration) withLocation(location Location) *HclConfiguration {
 }
 
 func (c *HclConfiguration) LoadedFiles() []string {
-	filepaths := []string{}
+	filepaths := []string{filepath.Join(c.dir, ".terraform")}
 	if c.recurse {
 		filepaths = append(filepaths, c.dir)
 	}


### PR DESCRIPTION
This PR makes two changes:
1. Regula will no longer recurse into directories that have already been loaded. Right now, this situation only occurs for Terraform configurations.
2. It adds the `.terraform` directory to the list of loaded paths for Terraform configurations.

These changes fix a bug where we're loading modules and their examples as separate configurations in some scenarios.