### PR TITLE
[RM-5895] Sort locals topologically before in HCL renderer

### DIFF
--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -33,6 +33,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/fugue/regula/pkg/topsort"
+
 	"tf_resource_schemas"
 )
 
@@ -612,9 +614,33 @@ func (c *HclConfiguration) renderContext(self string) renderContext {
 	}
 
 	if ctx.locals == nil {
-		ctx.locals = make(map[string]interface{})
-		for k, local := range c.module.Locals {
-			ctx.locals[k] = ctx.EvaluateExpr(local.Expr)
+		// Build dependency graph, perform topological sort.
+		deps := map[string][]string{}
+		for _, local := range c.module.Locals {
+    		k := "local."+local.Name
+    		deps[k] = []string{}
+    		for _, traversal := range local.Expr.Variables() {
+        		parts := ctx.RenderTraversal(traversal)
+        		deps[k] = append(deps[k], strings.Join(parts, "."))
+    		}
+		}
+		sorted, err := topsort.Topsort(deps)
+		if err != nil {
+    		logrus.Warnf("While analyzing locals: %s", err)
+    		sorted = []string{}
+		} else {
+    		for i, k := range sorted {
+        		sorted[i] = strings.TrimPrefix(k, "local.")
+    		}
+		}
+
+		// Now actually compute locals.
+		ctx.locals = map[string]interface{}{}
+        for _, k := range sorted {
+            local := c.module.Locals[k]
+			val := ctx.EvaluateExpr(local.Expr)
+			ctx.locals[k] = val
+			logrus.Debugf("Set local %s to %v", k, val)
 		}
 		c.locals = ctx.locals
 	}

--- a/pkg/topsort/topsort.go
+++ b/pkg/topsort/topsort.go
@@ -1,0 +1,78 @@
+package topsort
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Key = string
+type Graph = map[Key][]Key
+
+// Simple topological sort for a string-based dependency graph.
+func Topsort(original Graph) ([]Key, error) {
+	sorted := []string{}
+	done := map[Key]struct{}{}
+
+	// Create working copy as we will mutate the graph.
+	g := Graph{}
+	for k, nbs := range original {
+		g[k] = make([]Key, len(nbs))
+		copy(g[k], nbs)
+	}
+
+	// Pop a random node.
+	for curr := pop(g); curr != nil; curr = pop(g) {
+		visited := map[Key]struct{}{}
+
+		// Follow until no dependencies.
+		next := curr
+		for next != nil {
+			curr = next
+
+			// Check for cycles.
+			if _, ok := visited[*curr]; ok {
+				cycle := []string{}
+				for k := range visited {
+					cycle = append(cycle, k)
+				}
+				return nil, fmt.Errorf("Variables form a cycle: " + strings.Join(cycle, ", "))
+			} else {
+				visited[*curr] = struct{}{}
+			}
+
+			// Find a neighbor that isn't done.
+			neighbors := g[*curr]
+			next = nil
+			for i := 0; i < len(neighbors) && next == nil; {
+				k := neighbors[i]
+				if _, exists := g[k]; !exists {
+					// Trim in-place if not exists to make subsequent runs fast.
+					neighbors = append(neighbors[:i], neighbors[i+1:]...)
+					g[*curr] = neighbors
+				} else if _, isDone := done[k]; !isDone {
+					// Found an element that's not done.
+					curr = next
+					next = &k
+				} else {
+					// Try next neighbor.
+					i += 1
+				}
+			}
+		}
+
+		// Add to sorted once we're done and remove from the graph.
+		sorted = append(sorted, *curr)
+		done[*curr] = struct{}{}
+		delete(g, *curr)
+	}
+
+	return sorted, nil
+}
+
+// Pops a random key from a graph
+func pop(g Graph) *Key {
+	for k := range g {
+		return &k
+	}
+	return nil
+}

--- a/pkg/topsort/topsort_test.go
+++ b/pkg/topsort/topsort_test.go
@@ -1,0 +1,93 @@
+package topsort
+
+import (
+	"testing"
+)
+
+func Test_topsort(t *testing.T) {
+	type Test struct {
+		name         string
+		entries      []Key
+		dependencies [][]Key
+		expectError  bool
+	}
+
+	tests := []Test{
+		{
+			name:    "Simple",
+			entries: []Key{"one", "two", "three"},
+			dependencies: [][]Key{
+				{"one", "two"},
+				{"two", "three"},
+			},
+		},
+		{
+			name:    "Cycle",
+			entries: []Key{"one", "two", "three"},
+			dependencies: [][]Key{
+				{"one", "two"},
+				{"two", "three"},
+				{"three", "one"},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Cliques",
+			entries: []Key{"one", "two", "three", "four", "five"},
+			dependencies: [][]Key{
+				{"one", "two"},
+				{"two", "three"},
+				{"five", "four"},
+			},
+		},
+		{
+			name:    "Non-existing dependencies",
+			entries: []Key{"one", "two", "three"},
+			dependencies: [][]Key{
+				{"one", "een"},
+				{"two", "twee"},
+				{"three", "one"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build graph
+			g := make(Graph)
+			for _, k := range tc.entries {
+				g[k] = []Key{}
+			}
+			for _, dependency := range tc.dependencies {
+				k := dependency[0]
+				g[k] = append(g[k], dependency[1])
+			}
+
+			// Run topsort
+			sorted, err := Topsort(g)
+
+			// Check error
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("Expected error but succeeded")
+				}
+			} else {
+				// Check that every item appears after all its dependencies
+				indices := map[string]int{}
+				for i, k := range sorted {
+					indices[k] = i
+				}
+				for _, dependency := range tc.dependencies {
+					k := dependency[0]
+					l := dependency[1]
+					i := indices[k]
+					if j, ok := indices[l]; ok {
+						if i <= j {
+							t.Fatalf("Expected '%s' after '%s' but they have indices %d and %d", k, l, i, j)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This prevents some issues that we were seeing due to Golang's random map iteration order.