### PR TITLE
[RM-5932] Turn single quotes into double quotes

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -27,8 +27,9 @@ import (
 	"strings"
 
 	"github.com/fugue/regula/pkg/loader"
-	"github.com/fugue/regula/pkg/metadoc"
 	"github.com/fugue/regula/pkg/rego"
+	"github.com/fugue/regula/pkg/regotools/doublequote"
+	"github.com/fugue/regula/pkg/regotools/metadoc"
 	"github.com/fugue/regula/pkg/swagger/client"
 	apiclient "github.com/fugue/regula/pkg/swagger/client"
 	"github.com/fugue/regula/pkg/swagger/client/custom_rules"
@@ -120,7 +121,9 @@ func processCustomRule(rule *models.CustomRule) (string, error) {
 	// Ensure data.fugue import is there.
 	regometa.Imports[metadoc.Import{Path: "data.fugue"}] = struct{}{}
 
-	return regometa.String(), nil
+	// Turn single quotes into double quotes.
+	text := doublequote.Doublequote(regometa.String())
+	return text, nil
 }
 
 func temporaryCustomRulesDir(ctx context.Context, client *client.Fugue, auth runtime.ClientAuthInfoWriter) (string, error) {

--- a/pkg/regotools/doublequote/doublequote.go
+++ b/pkg/regotools/doublequote/doublequote.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doublequote
+
+import (
+	"strings"
+)
+
+const (
+	initial = iota
+	in_comment
+	in_double_quote
+	in_single_quote
+	in_raw
+)
+
+// Doublequote turns Rego code that may have single quotes (as supported by
+// fregot) into Rego code that doesn't have these without changing the meaning
+// of the code.
+func Doublequote(input string) string {
+	var sb strings.Builder
+	state := initial
+	escaping := false
+
+	for _, c := range input {
+		switch state {
+		case initial:
+			switch c {
+			case '#':
+				state = in_comment
+			case '"':
+				state = in_double_quote
+			case '\'':
+				state = in_single_quote
+				sb.WriteRune('"')
+				continue
+			case '`':
+				state = in_raw
+			}
+		case in_comment:
+			switch c {
+			case '\n':
+				state = initial
+			}
+		case in_double_quote:
+			if !escaping {
+				switch c {
+				case '"':
+					state = initial
+				case '\\':
+					escaping = true
+					sb.WriteRune(c)
+					continue
+				}
+			}
+		case in_single_quote:
+			if !escaping {
+				switch c {
+				case '\'':
+					state = initial
+					sb.WriteRune('"')
+					continue
+				case '"':
+					sb.WriteRune('\\')
+				case '\\':
+					escaping = true
+					sb.WriteRune(c)
+					continue
+				}
+			}
+		case in_raw:
+			switch c {
+			case '`':
+				state = initial
+			}
+		}
+
+		sb.WriteRune(c)
+		escaping = false
+	}
+
+	return sb.String()
+}

--- a/pkg/regotools/doublequote/doublequote_test.go
+++ b/pkg/regotools/doublequote/doublequote_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doublequote
+
+import (
+	"testing"
+)
+
+func Test_Doublequote(t *testing.T) {
+	type Test struct {
+		input    string
+		expected string
+	}
+
+	tests := []Test{
+		{
+			input: `
+# Comment 'quoted'
+value = 'single_quoted'
+value = "double_quoted"`,
+			expected: `
+# Comment 'quoted'
+value = "single_quoted"
+value = "double_quoted"`,
+		},
+		{
+			input: `
+raw_string = ` + "`" + `some value
+with 'single quotes'` + "`" + `
+# Comment 'quoted'`,
+		},
+		{
+			input: `
+value = 'some "resource" is bad'
+value = "some 'resource' is bad"
+value = 'some \"resource\" is bad'`,
+			expected: `
+value = "some \"resource\" is bad"
+value = "some 'resource' is bad"
+value = "some \"resource\" is bad"`,
+		},
+	}
+
+	for _, tc := range tests {
+		actual := Doublequote(tc.input)
+		expected := tc.expected
+		if expected == "" {
+			expected = tc.input
+		}
+		if actual != expected {
+			t.Fatalf("Expected: %s\nGot: %s", expected, actual)
+		}
+	}
+}

--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metadoc
 
 import (

--- a/pkg/regotools/metadoc/metadoc_test.go
+++ b/pkg/regotools/metadoc/metadoc_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metadoc
 
 import (


### PR DESCRIPTION
This also moves the metadoc package inside regotools to make the organization a
bit cleaner.