### PR TITLE
[RM-5934] Remove buckets_with_valid_policies

### DIFF
--- a/rego/lib/aws/iam/policy_document_library.rego
+++ b/rego/lib/aws/iam/policy_document_library.rego
@@ -68,24 +68,13 @@ policy_documents := {global_id: ret |
   ret := make_document(doc)
 }
 
-policy_document_ref_or_json_string(p) = true {
-  _ = policy_documents[_]
-} else = true {
-  startswith(trim_space(p), "{")
-  endswith(trim_space(p), "}")
-} else = false {
-  true
-}
-
 to_policy_document(pol) = ret {
   ret := policy_documents[pol]
 } else = ret {
   is_array(pol)
   ret := policy_documents[pol[0]]
 } else = ret {
-  is_string(pol)
-  startswith(trim_space(pol), "{")
-  endswith(trim_space(pol), "}")
+  json.is_valid(pol)
   ret := json.unmarshal(pol)
 }
 

--- a/rego/lib/aws/s3/s3_library.rego
+++ b/rego/lib/aws/s3/s3_library.rego
@@ -14,7 +14,6 @@
 package aws.s3.s3_library
 
 import data.fugue
-import data.aws.iam.policy_document_library as doclib
 
 # Retrieves all bucket policies for a bucket, returned as a list.
 # Bucket policies can be defined as part of the bucket or as
@@ -37,11 +36,5 @@ bucket_name_or_id(bucket) = ret {
   ret = bucket.name
 } {
   ret = bucket.id
-}
-
-buckets_with_valid_policies[id] = bucket {
-  bucket = fugue.resources("aws_s3_bucket")[id]
-  policies = bucket_policies_for_bucket(bucket)
-  all([doclib.policy_document_ref_or_json_string(p) | p = policies[_]])
 }
 

--- a/rego/rules/tf/aws/s3/bucket_config_public_read.rego
+++ b/rego/rules/tf/aws/s3/bucket_config_public_read.rego
@@ -38,7 +38,7 @@ resource_type = "MULTIPLE"
 
 base_message = "S3 buckets should not be configured for public access:"
 
-buckets = lib.buckets_with_valid_policies
+buckets = fugue.resources("aws_s3_bucket")
 
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
 # Invalid canned ACL is "public-read", "public-read-write",

--- a/rego/rules/tf/aws/s3/bucket_is_public.rego
+++ b/rego/rules/tf/aws/s3/bucket_is_public.rego
@@ -40,7 +40,7 @@ resource_type = "MULTIPLE"
 
 base_message = "S3 buckets should not be publicly readable:"
 
-buckets = lib.buckets_with_valid_policies
+buckets = fugue.resources("aws_s3_bucket")
 bucket_access_blocks = fugue.resources("aws_s3_bucket_public_access_block")
 account_access_blocks = fugue.resources("aws_s3_account_public_access_block")
 

--- a/rego/rules/tf/aws/s3/bucketpolicy_allowall.rego
+++ b/rego/rules/tf/aws/s3/bucketpolicy_allowall.rego
@@ -36,7 +36,7 @@ __rego__metadoc__ := {
 
 resource_type = "MULTIPLE"
 
-buckets = lib.buckets_with_valid_policies
+buckets = fugue.resources("aws_s3_bucket")
 
 invalid_buckets[bucket_id] = bucket {
   bucket = buckets[bucket_id]

--- a/rego/rules/tf/aws/s3/bucketpolicy_allowlist.rego
+++ b/rego/rules/tf/aws/s3/bucketpolicy_allowlist.rego
@@ -36,7 +36,7 @@ __rego__metadoc__ := {
 
 resource_type = "MULTIPLE"
 
-buckets = lib.buckets_with_valid_policies
+buckets = fugue.resources("aws_s3_bucket")
 
 invalid_buckets[bucket_id] = bucket {
   bucket = buckets[bucket_id]

--- a/rego/rules/tf/aws/s3/https_access.rego
+++ b/rego/rules/tf/aws/s3/https_access.rego
@@ -48,7 +48,7 @@ specifies_secure_transport(statement) {
   related_actions[actions[_]]
 }
 
-buckets = lib.buckets_with_valid_policies
+buckets = fugue.resources("aws_s3_bucket")
 
 # A valid policy specifies a `specifies_secure_transport` statement for the
 # "s3:GetObject" method.  See also:

--- a/rego/rules/tf/aws/sqs/granular_access.rego
+++ b/rego/rules/tf/aws/sqs/granular_access.rego
@@ -47,6 +47,7 @@ statement_has_condition(statement) {
 }
 
 allow_all(pol) {
+  json.is_valid(pol)
   doc = json.unmarshal(pol)
   statements = as_array(doc.Statement)
   statement = statements[_]


### PR DESCRIPTION
`policy_document_ref_or_json_string` is meant to decide whether or not a policy
document is valid.  However, there was a bug in this function, resulting in all
inputs being treated as valid if a single policy policy data document exists.

However, this is only used in `s3_library.buckets_with_valid_policies`, which is
a bit of an antipattern: it first checked which buckets only have valid (valid
as in well-formatted JSON) policies, and then uses these in whatever rule.

It is much better to just iterate over all buckets and policy pairs, and discard
only the invalid ones.  That way a single invalid policy doesn't cause our
system to skip the other policies.