### PR TITLE
[RM-5916] Add link to rule documentation in output report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ NEXT_MINOR = $(shell $(CHANGIE) next minor)
 NEXT_PATCH = $(shell $(CHANGIE) next patch)
 VERSION = $(shell $(CHANGIE) latest)
 
+REMEDIATION_LINKS = rego/rules/remediation.yaml
+
 ##############
 #   Swagger  #
 ##############
@@ -71,7 +73,7 @@ install_tools: $(GOLINT) $(MOCKGEN) $(CHANGIE) $(GORELEASER)
 # Dev builds #
 ##############
 
-$(BINARY): $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE)
+$(BINARY): $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE) $(REMEDIATION_LINKS)
 	$(CLI_BUILD) -v -o $@
 
 $(INSTALLED_BINARY): $(BINARY)
@@ -106,6 +108,13 @@ docker: $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE)
 	GOOS=linux GOARCH=amd64 $(CLI_BUILD) -v -o dist/regula
 	cp Dockerfile dist
 	cd dist && docker build --tag fugue/regula:dev .
+
+################################
+#   Remediation documentation  #
+################################
+
+$(REMEDIATION_LINKS):
+	curl -s "https://docs.fugue.co/remediation.html" | grep -Eo 'FG_R[0-9]+' | sort -u | awk '{ print $$1 ":\n  url: https://docs.fugue.co/" $$1 ".html" }' > "$@"
 
 #####################
 # Release processes #

--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 
 	"github.com/fugue/regula/pkg/loader"
+	embedded "github.com/fugue/regula/rego"
 	"github.com/open-policy-agent/opa/rego"
 )
 
@@ -177,6 +178,16 @@ func (o RegulaOutput) AggregateByFilepath() ResultsByFilepath {
 	return byFilepath
 }
 
+// Get the URL of the remediation documenation, or "" if no such documentation
+// exists (to our knowledge).
+func getRemediationDoc(RuleID string) string {
+	if val, ok := embedded.RegulaRemediations[RuleID]; ok {
+		return val.URL
+	}
+
+	return ""
+}
+
 // AggregateByRule returns all rule results grouped by rule
 func (o RegulaOutput) AggregateByRule() ResultsByRule {
 
@@ -202,11 +213,12 @@ func (o RegulaOutput) AggregateByRule() ResultsByRule {
 			return resultA.ResourceID < resultB.ResourceID
 		})
 		output = append(output, RuleResults{
-			RuleID:       results[0].RuleID,
-			RuleName:     results[0].RuleName,
-			RuleSummary:  results[0].RuleSummary,
-			RuleSeverity: results[0].RuleSeverity,
-			Results:      results,
+			RuleID:             results[0].RuleID,
+			RuleName:           results[0].RuleName,
+			RuleSummary:        results[0].RuleSummary,
+			RuleSeverity:       results[0].RuleSeverity,
+			RuleRemediationDoc: getRemediationDoc(results[0].RuleID),
+			Results:            results,
 		})
 	}
 
@@ -316,11 +328,12 @@ type Reporter func(r *RegulaOutput) (string, error)
 // RuleResults carries a slice of RuleResults associated with a specific rule.
 // A minimal amount of rule metadata is duplicated here for convenience.
 type RuleResults struct {
-	RuleID       string
-	RuleName     string
-	RuleSummary  string
-	RuleSeverity string
-	Results      []*RuleResult
+	RuleID             string
+	RuleName           string
+	RuleSummary        string
+	RuleSeverity       string
+	RuleRemediationDoc string
+	Results            []*RuleResult
 }
 
 // ResultsByRule is used to carry all rule results grouped by rule

--- a/pkg/reporter/text.tmpl
+++ b/pkg/reporter/text.tmpl
@@ -7,6 +7,9 @@
 {{- else -}}
 {{- Cyan $ruleResults.RuleName }}
 {{- end -}}: {{- Bold " " $ruleResults.RuleSummary }} {{ Severity $ruleResults.RuleSeverity }}
+{{- if not (eq $ruleResults.RuleRemediationDoc "") }}
+     {{ PadIndex nil (len $ruleResults.RuleID) }} {{ $ruleResults.RuleRemediationDoc }}
+{{- end }}
 {{/* RULE RESULTS FOR A SINGLE RULE */}}
 {{- range $index, $rr := $ruleResults.Results }}
   {{ ResultIndex $rr $index }} {{ $rr.ResourceID }}

--- a/rego/embedded.go
+++ b/rego/embedded.go
@@ -2,6 +2,8 @@ package rego
 
 import (
 	"embed"
+
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed lib
@@ -9,3 +11,17 @@ var RegulaLib embed.FS
 
 //go:embed rules
 var RegulaRules embed.FS
+
+//go:embed remediation.yaml
+var regulaRemediations string
+
+type RemediationRuleInfo struct {
+	URL string `yaml:"url"`
+}
+
+var RegulaRemediations map[string]RemediationRuleInfo = nil
+
+func init() {
+	RegulaRemediations = make(map[string]RemediationRuleInfo)
+	yaml.Unmarshal([]byte(regulaRemediations), &RegulaRemediations)
+}

--- a/rego/remediation.yaml
+++ b/rego/remediation.yaml
@@ -1,0 +1,612 @@
+FG_R00001:
+  url: https://docs.fugue.co/FG_R00001.html
+FG_R00002:
+  url: https://docs.fugue.co/FG_R00002.html
+FG_R00003:
+  url: https://docs.fugue.co/FG_R00003.html
+FG_R00004:
+  url: https://docs.fugue.co/FG_R00004.html
+FG_R00005:
+  url: https://docs.fugue.co/FG_R00005.html
+FG_R00006:
+  url: https://docs.fugue.co/FG_R00006.html
+FG_R00007:
+  url: https://docs.fugue.co/FG_R00007.html
+FG_R00009:
+  url: https://docs.fugue.co/FG_R00009.html
+FG_R00010:
+  url: https://docs.fugue.co/FG_R00010.html
+FG_R00011:
+  url: https://docs.fugue.co/FG_R00011.html
+FG_R00013:
+  url: https://docs.fugue.co/FG_R00013.html
+FG_R00014:
+  url: https://docs.fugue.co/FG_R00014.html
+FG_R00016:
+  url: https://docs.fugue.co/FG_R00016.html
+FG_R00018:
+  url: https://docs.fugue.co/FG_R00018.html
+FG_R00019:
+  url: https://docs.fugue.co/FG_R00019.html
+FG_R00020:
+  url: https://docs.fugue.co/FG_R00020.html
+FG_R00021:
+  url: https://docs.fugue.co/FG_R00021.html
+FG_R00022:
+  url: https://docs.fugue.co/FG_R00022.html
+FG_R00023:
+  url: https://docs.fugue.co/FG_R00023.html
+FG_R00024:
+  url: https://docs.fugue.co/FG_R00024.html
+FG_R00025:
+  url: https://docs.fugue.co/FG_R00025.html
+FG_R00026:
+  url: https://docs.fugue.co/FG_R00026.html
+FG_R00027:
+  url: https://docs.fugue.co/FG_R00027.html
+FG_R00028:
+  url: https://docs.fugue.co/FG_R00028.html
+FG_R00029:
+  url: https://docs.fugue.co/FG_R00029.html
+FG_R00030:
+  url: https://docs.fugue.co/FG_R00030.html
+FG_R00031:
+  url: https://docs.fugue.co/FG_R00031.html
+FG_R00032:
+  url: https://docs.fugue.co/FG_R00032.html
+FG_R00034:
+  url: https://docs.fugue.co/FG_R00034.html
+FG_R00035:
+  url: https://docs.fugue.co/FG_R00035.html
+FG_R00036:
+  url: https://docs.fugue.co/FG_R00036.html
+FG_R00037:
+  url: https://docs.fugue.co/FG_R00037.html
+FG_R00038:
+  url: https://docs.fugue.co/FG_R00038.html
+FG_R00039:
+  url: https://docs.fugue.co/FG_R00039.html
+FG_R00040:
+  url: https://docs.fugue.co/FG_R00040.html
+FG_R00041:
+  url: https://docs.fugue.co/FG_R00041.html
+FG_R00043:
+  url: https://docs.fugue.co/FG_R00043.html
+FG_R00044:
+  url: https://docs.fugue.co/FG_R00044.html
+FG_R00045:
+  url: https://docs.fugue.co/FG_R00045.html
+FG_R00047:
+  url: https://docs.fugue.co/FG_R00047.html
+FG_R00049:
+  url: https://docs.fugue.co/FG_R00049.html
+FG_R00052:
+  url: https://docs.fugue.co/FG_R00052.html
+FG_R00054:
+  url: https://docs.fugue.co/FG_R00054.html
+FG_R00055:
+  url: https://docs.fugue.co/FG_R00055.html
+FG_R00056:
+  url: https://docs.fugue.co/FG_R00056.html
+FG_R00057:
+  url: https://docs.fugue.co/FG_R00057.html
+FG_R00058:
+  url: https://docs.fugue.co/FG_R00058.html
+FG_R00059:
+  url: https://docs.fugue.co/FG_R00059.html
+FG_R00060:
+  url: https://docs.fugue.co/FG_R00060.html
+FG_R00061:
+  url: https://docs.fugue.co/FG_R00061.html
+FG_R00062:
+  url: https://docs.fugue.co/FG_R00062.html
+FG_R00063:
+  url: https://docs.fugue.co/FG_R00063.html
+FG_R00064:
+  url: https://docs.fugue.co/FG_R00064.html
+FG_R00065:
+  url: https://docs.fugue.co/FG_R00065.html
+FG_R00066:
+  url: https://docs.fugue.co/FG_R00066.html
+FG_R00067:
+  url: https://docs.fugue.co/FG_R00067.html
+FG_R00068:
+  url: https://docs.fugue.co/FG_R00068.html
+FG_R00069:
+  url: https://docs.fugue.co/FG_R00069.html
+FG_R00070:
+  url: https://docs.fugue.co/FG_R00070.html
+FG_R00073:
+  url: https://docs.fugue.co/FG_R00073.html
+FG_R00082:
+  url: https://docs.fugue.co/FG_R00082.html
+FG_R00083:
+  url: https://docs.fugue.co/FG_R00083.html
+FG_R00084:
+  url: https://docs.fugue.co/FG_R00084.html
+FG_R00085:
+  url: https://docs.fugue.co/FG_R00085.html
+FG_R00086:
+  url: https://docs.fugue.co/FG_R00086.html
+FG_R00087:
+  url: https://docs.fugue.co/FG_R00087.html
+FG_R00088:
+  url: https://docs.fugue.co/FG_R00088.html
+FG_R00089:
+  url: https://docs.fugue.co/FG_R00089.html
+FG_R00092:
+  url: https://docs.fugue.co/FG_R00092.html
+FG_R00093:
+  url: https://docs.fugue.co/FG_R00093.html
+FG_R00094:
+  url: https://docs.fugue.co/FG_R00094.html
+FG_R00098:
+  url: https://docs.fugue.co/FG_R00098.html
+FG_R00099:
+  url: https://docs.fugue.co/FG_R00099.html
+FG_R00100:
+  url: https://docs.fugue.co/FG_R00100.html
+FG_R00101:
+  url: https://docs.fugue.co/FG_R00101.html
+FG_R00102:
+  url: https://docs.fugue.co/FG_R00102.html
+FG_R00103:
+  url: https://docs.fugue.co/FG_R00103.html
+FG_R00104:
+  url: https://docs.fugue.co/FG_R00104.html
+FG_R00105:
+  url: https://docs.fugue.co/FG_R00105.html
+FG_R00106:
+  url: https://docs.fugue.co/FG_R00106.html
+FG_R00107:
+  url: https://docs.fugue.co/FG_R00107.html
+FG_R00109:
+  url: https://docs.fugue.co/FG_R00109.html
+FG_R00152:
+  url: https://docs.fugue.co/FG_R00152.html
+FG_R00154:
+  url: https://docs.fugue.co/FG_R00154.html
+FG_R00190:
+  url: https://docs.fugue.co/FG_R00190.html
+FG_R00191:
+  url: https://docs.fugue.co/FG_R00191.html
+FG_R00192:
+  url: https://docs.fugue.co/FG_R00192.html
+FG_R00194:
+  url: https://docs.fugue.co/FG_R00194.html
+FG_R00196:
+  url: https://docs.fugue.co/FG_R00196.html
+FG_R00197:
+  url: https://docs.fugue.co/FG_R00197.html
+FG_R00208:
+  url: https://docs.fugue.co/FG_R00208.html
+FG_R00209:
+  url: https://docs.fugue.co/FG_R00209.html
+FG_R00210:
+  url: https://docs.fugue.co/FG_R00210.html
+FG_R00211:
+  url: https://docs.fugue.co/FG_R00211.html
+FG_R00212:
+  url: https://docs.fugue.co/FG_R00212.html
+FG_R00213:
+  url: https://docs.fugue.co/FG_R00213.html
+FG_R00214:
+  url: https://docs.fugue.co/FG_R00214.html
+FG_R00215:
+  url: https://docs.fugue.co/FG_R00215.html
+FG_R00216:
+  url: https://docs.fugue.co/FG_R00216.html
+FG_R00217:
+  url: https://docs.fugue.co/FG_R00217.html
+FG_R00218:
+  url: https://docs.fugue.co/FG_R00218.html
+FG_R00219:
+  url: https://docs.fugue.co/FG_R00219.html
+FG_R00220:
+  url: https://docs.fugue.co/FG_R00220.html
+FG_R00221:
+  url: https://docs.fugue.co/FG_R00221.html
+FG_R00222:
+  url: https://docs.fugue.co/FG_R00222.html
+FG_R00223:
+  url: https://docs.fugue.co/FG_R00223.html
+FG_R00224:
+  url: https://docs.fugue.co/FG_R00224.html
+FG_R00225:
+  url: https://docs.fugue.co/FG_R00225.html
+FG_R00226:
+  url: https://docs.fugue.co/FG_R00226.html
+FG_R00227:
+  url: https://docs.fugue.co/FG_R00227.html
+FG_R00229:
+  url: https://docs.fugue.co/FG_R00229.html
+FG_R00234:
+  url: https://docs.fugue.co/FG_R00234.html
+FG_R00235:
+  url: https://docs.fugue.co/FG_R00235.html
+FG_R00236:
+  url: https://docs.fugue.co/FG_R00236.html
+FG_R00237:
+  url: https://docs.fugue.co/FG_R00237.html
+FG_R00238:
+  url: https://docs.fugue.co/FG_R00238.html
+FG_R00239:
+  url: https://docs.fugue.co/FG_R00239.html
+FG_R00240:
+  url: https://docs.fugue.co/FG_R00240.html
+FG_R00242:
+  url: https://docs.fugue.co/FG_R00242.html
+FG_R00243:
+  url: https://docs.fugue.co/FG_R00243.html
+FG_R00244:
+  url: https://docs.fugue.co/FG_R00244.html
+FG_R00245:
+  url: https://docs.fugue.co/FG_R00245.html
+FG_R00246:
+  url: https://docs.fugue.co/FG_R00246.html
+FG_R00247:
+  url: https://docs.fugue.co/FG_R00247.html
+FG_R00248:
+  url: https://docs.fugue.co/FG_R00248.html
+FG_R00249:
+  url: https://docs.fugue.co/FG_R00249.html
+FG_R00251:
+  url: https://docs.fugue.co/FG_R00251.html
+FG_R00252:
+  url: https://docs.fugue.co/FG_R00252.html
+FG_R00253:
+  url: https://docs.fugue.co/FG_R00253.html
+FG_R00255:
+  url: https://docs.fugue.co/FG_R00255.html
+FG_R00256:
+  url: https://docs.fugue.co/FG_R00256.html
+FG_R00257:
+  url: https://docs.fugue.co/FG_R00257.html
+FG_R00258:
+  url: https://docs.fugue.co/FG_R00258.html
+FG_R00259:
+  url: https://docs.fugue.co/FG_R00259.html
+FG_R00260:
+  url: https://docs.fugue.co/FG_R00260.html
+FG_R00261:
+  url: https://docs.fugue.co/FG_R00261.html
+FG_R00262:
+  url: https://docs.fugue.co/FG_R00262.html
+FG_R00263:
+  url: https://docs.fugue.co/FG_R00263.html
+FG_R00264:
+  url: https://docs.fugue.co/FG_R00264.html
+FG_R00265:
+  url: https://docs.fugue.co/FG_R00265.html
+FG_R00266:
+  url: https://docs.fugue.co/FG_R00266.html
+FG_R00267:
+  url: https://docs.fugue.co/FG_R00267.html
+FG_R00268:
+  url: https://docs.fugue.co/FG_R00268.html
+FG_R00270:
+  url: https://docs.fugue.co/FG_R00270.html
+FG_R00271:
+  url: https://docs.fugue.co/FG_R00271.html
+FG_R00272:
+  url: https://docs.fugue.co/FG_R00272.html
+FG_R00273:
+  url: https://docs.fugue.co/FG_R00273.html
+FG_R00274:
+  url: https://docs.fugue.co/FG_R00274.html
+FG_R00275:
+  url: https://docs.fugue.co/FG_R00275.html
+FG_R00276:
+  url: https://docs.fugue.co/FG_R00276.html
+FG_R00277:
+  url: https://docs.fugue.co/FG_R00277.html
+FG_R00278:
+  url: https://docs.fugue.co/FG_R00278.html
+FG_R00279:
+  url: https://docs.fugue.co/FG_R00279.html
+FG_R00280:
+  url: https://docs.fugue.co/FG_R00280.html
+FG_R00282:
+  url: https://docs.fugue.co/FG_R00282.html
+FG_R00283:
+  url: https://docs.fugue.co/FG_R00283.html
+FG_R00286:
+  url: https://docs.fugue.co/FG_R00286.html
+FG_R00288:
+  url: https://docs.fugue.co/FG_R00288.html
+FG_R00289:
+  url: https://docs.fugue.co/FG_R00289.html
+FG_R00290:
+  url: https://docs.fugue.co/FG_R00290.html
+FG_R00300:
+  url: https://docs.fugue.co/FG_R00300.html
+FG_R00301:
+  url: https://docs.fugue.co/FG_R00301.html
+FG_R00302:
+  url: https://docs.fugue.co/FG_R00302.html
+FG_R00303:
+  url: https://docs.fugue.co/FG_R00303.html
+FG_R00304:
+  url: https://docs.fugue.co/FG_R00304.html
+FG_R00305:
+  url: https://docs.fugue.co/FG_R00305.html
+FG_R00306:
+  url: https://docs.fugue.co/FG_R00306.html
+FG_R00307:
+  url: https://docs.fugue.co/FG_R00307.html
+FG_R00308:
+  url: https://docs.fugue.co/FG_R00308.html
+FG_R00309:
+  url: https://docs.fugue.co/FG_R00309.html
+FG_R00310:
+  url: https://docs.fugue.co/FG_R00310.html
+FG_R00311:
+  url: https://docs.fugue.co/FG_R00311.html
+FG_R00312:
+  url: https://docs.fugue.co/FG_R00312.html
+FG_R00317:
+  url: https://docs.fugue.co/FG_R00317.html
+FG_R00318:
+  url: https://docs.fugue.co/FG_R00318.html
+FG_R00320:
+  url: https://docs.fugue.co/FG_R00320.html
+FG_R00321:
+  url: https://docs.fugue.co/FG_R00321.html
+FG_R00322:
+  url: https://docs.fugue.co/FG_R00322.html
+FG_R00323:
+  url: https://docs.fugue.co/FG_R00323.html
+FG_R00324:
+  url: https://docs.fugue.co/FG_R00324.html
+FG_R00325:
+  url: https://docs.fugue.co/FG_R00325.html
+FG_R00326:
+  url: https://docs.fugue.co/FG_R00326.html
+FG_R00327:
+  url: https://docs.fugue.co/FG_R00327.html
+FG_R00328:
+  url: https://docs.fugue.co/FG_R00328.html
+FG_R00329:
+  url: https://docs.fugue.co/FG_R00329.html
+FG_R00331:
+  url: https://docs.fugue.co/FG_R00331.html
+FG_R00333:
+  url: https://docs.fugue.co/FG_R00333.html
+FG_R00335:
+  url: https://docs.fugue.co/FG_R00335.html
+FG_R00337:
+  url: https://docs.fugue.co/FG_R00337.html
+FG_R00339:
+  url: https://docs.fugue.co/FG_R00339.html
+FG_R00340:
+  url: https://docs.fugue.co/FG_R00340.html
+FG_R00341:
+  url: https://docs.fugue.co/FG_R00341.html
+FG_R00342:
+  url: https://docs.fugue.co/FG_R00342.html
+FG_R00344:
+  url: https://docs.fugue.co/FG_R00344.html
+FG_R00345:
+  url: https://docs.fugue.co/FG_R00345.html
+FG_R00346:
+  url: https://docs.fugue.co/FG_R00346.html
+FG_R00347:
+  url: https://docs.fugue.co/FG_R00347.html
+FG_R00348:
+  url: https://docs.fugue.co/FG_R00348.html
+FG_R00350:
+  url: https://docs.fugue.co/FG_R00350.html
+FG_R00351:
+  url: https://docs.fugue.co/FG_R00351.html
+FG_R00354:
+  url: https://docs.fugue.co/FG_R00354.html
+FG_R00355:
+  url: https://docs.fugue.co/FG_R00355.html
+FG_R00356:
+  url: https://docs.fugue.co/FG_R00356.html
+FG_R00357:
+  url: https://docs.fugue.co/FG_R00357.html
+FG_R00359:
+  url: https://docs.fugue.co/FG_R00359.html
+FG_R00360:
+  url: https://docs.fugue.co/FG_R00360.html
+FG_R00361:
+  url: https://docs.fugue.co/FG_R00361.html
+FG_R00362:
+  url: https://docs.fugue.co/FG_R00362.html
+FG_R00364:
+  url: https://docs.fugue.co/FG_R00364.html
+FG_R00365:
+  url: https://docs.fugue.co/FG_R00365.html
+FG_R00366:
+  url: https://docs.fugue.co/FG_R00366.html
+FG_R00367:
+  url: https://docs.fugue.co/FG_R00367.html
+FG_R00369:
+  url: https://docs.fugue.co/FG_R00369.html
+FG_R00370:
+  url: https://docs.fugue.co/FG_R00370.html
+FG_R00371:
+  url: https://docs.fugue.co/FG_R00371.html
+FG_R00372:
+  url: https://docs.fugue.co/FG_R00372.html
+FG_R00373:
+  url: https://docs.fugue.co/FG_R00373.html
+FG_R00374:
+  url: https://docs.fugue.co/FG_R00374.html
+FG_R00375:
+  url: https://docs.fugue.co/FG_R00375.html
+FG_R00383:
+  url: https://docs.fugue.co/FG_R00383.html
+FG_R00384:
+  url: https://docs.fugue.co/FG_R00384.html
+FG_R00385:
+  url: https://docs.fugue.co/FG_R00385.html
+FG_R00386:
+  url: https://docs.fugue.co/FG_R00386.html
+FG_R00387:
+  url: https://docs.fugue.co/FG_R00387.html
+FG_R00388:
+  url: https://docs.fugue.co/FG_R00388.html
+FG_R00389:
+  url: https://docs.fugue.co/FG_R00389.html
+FG_R00391:
+  url: https://docs.fugue.co/FG_R00391.html
+FG_R00392:
+  url: https://docs.fugue.co/FG_R00392.html
+FG_R00393:
+  url: https://docs.fugue.co/FG_R00393.html
+FG_R00394:
+  url: https://docs.fugue.co/FG_R00394.html
+FG_R00395:
+  url: https://docs.fugue.co/FG_R00395.html
+FG_R00396:
+  url: https://docs.fugue.co/FG_R00396.html
+FG_R00397:
+  url: https://docs.fugue.co/FG_R00397.html
+FG_R00398:
+  url: https://docs.fugue.co/FG_R00398.html
+FG_R00399:
+  url: https://docs.fugue.co/FG_R00399.html
+FG_R00400:
+  url: https://docs.fugue.co/FG_R00400.html
+FG_R00401:
+  url: https://docs.fugue.co/FG_R00401.html
+FG_R00402:
+  url: https://docs.fugue.co/FG_R00402.html
+FG_R00403:
+  url: https://docs.fugue.co/FG_R00403.html
+FG_R00404:
+  url: https://docs.fugue.co/FG_R00404.html
+FG_R00405:
+  url: https://docs.fugue.co/FG_R00405.html
+FG_R00406:
+  url: https://docs.fugue.co/FG_R00406.html
+FG_R00407:
+  url: https://docs.fugue.co/FG_R00407.html
+FG_R00408:
+  url: https://docs.fugue.co/FG_R00408.html
+FG_R00409:
+  url: https://docs.fugue.co/FG_R00409.html
+FG_R00410:
+  url: https://docs.fugue.co/FG_R00410.html
+FG_R00411:
+  url: https://docs.fugue.co/FG_R00411.html
+FG_R00412:
+  url: https://docs.fugue.co/FG_R00412.html
+FG_R00413:
+  url: https://docs.fugue.co/FG_R00413.html
+FG_R00414:
+  url: https://docs.fugue.co/FG_R00414.html
+FG_R00415:
+  url: https://docs.fugue.co/FG_R00415.html
+FG_R00416:
+  url: https://docs.fugue.co/FG_R00416.html
+FG_R00417:
+  url: https://docs.fugue.co/FG_R00417.html
+FG_R00418:
+  url: https://docs.fugue.co/FG_R00418.html
+FG_R00419:
+  url: https://docs.fugue.co/FG_R00419.html
+FG_R00420:
+  url: https://docs.fugue.co/FG_R00420.html
+FG_R00421:
+  url: https://docs.fugue.co/FG_R00421.html
+FG_R00422:
+  url: https://docs.fugue.co/FG_R00422.html
+FG_R00423:
+  url: https://docs.fugue.co/FG_R00423.html
+FG_R00424:
+  url: https://docs.fugue.co/FG_R00424.html
+FG_R00425:
+  url: https://docs.fugue.co/FG_R00425.html
+FG_R00426:
+  url: https://docs.fugue.co/FG_R00426.html
+FG_R00427:
+  url: https://docs.fugue.co/FG_R00427.html
+FG_R00428:
+  url: https://docs.fugue.co/FG_R00428.html
+FG_R00429:
+  url: https://docs.fugue.co/FG_R00429.html
+FG_R00430:
+  url: https://docs.fugue.co/FG_R00430.html
+FG_R00431:
+  url: https://docs.fugue.co/FG_R00431.html
+FG_R00432:
+  url: https://docs.fugue.co/FG_R00432.html
+FG_R00433:
+  url: https://docs.fugue.co/FG_R00433.html
+FG_R00434:
+  url: https://docs.fugue.co/FG_R00434.html
+FG_R00435:
+  url: https://docs.fugue.co/FG_R00435.html
+FG_R00436:
+  url: https://docs.fugue.co/FG_R00436.html
+FG_R00437:
+  url: https://docs.fugue.co/FG_R00437.html
+FG_R00439:
+  url: https://docs.fugue.co/FG_R00439.html
+FG_R00441:
+  url: https://docs.fugue.co/FG_R00441.html
+FG_R00442:
+  url: https://docs.fugue.co/FG_R00442.html
+FG_R00444:
+  url: https://docs.fugue.co/FG_R00444.html
+FG_R00445:
+  url: https://docs.fugue.co/FG_R00445.html
+FG_R00446:
+  url: https://docs.fugue.co/FG_R00446.html
+FG_R00447:
+  url: https://docs.fugue.co/FG_R00447.html
+FG_R00448:
+  url: https://docs.fugue.co/FG_R00448.html
+FG_R00449:
+  url: https://docs.fugue.co/FG_R00449.html
+FG_R00450:
+  url: https://docs.fugue.co/FG_R00450.html
+FG_R00451:
+  url: https://docs.fugue.co/FG_R00451.html
+FG_R00452:
+  url: https://docs.fugue.co/FG_R00452.html
+FG_R00453:
+  url: https://docs.fugue.co/FG_R00453.html
+FG_R00454:
+  url: https://docs.fugue.co/FG_R00454.html
+FG_R00455:
+  url: https://docs.fugue.co/FG_R00455.html
+FG_R00456:
+  url: https://docs.fugue.co/FG_R00456.html
+FG_R00457:
+  url: https://docs.fugue.co/FG_R00457.html
+FG_R00458:
+  url: https://docs.fugue.co/FG_R00458.html
+FG_R00459:
+  url: https://docs.fugue.co/FG_R00459.html
+FG_R00460:
+  url: https://docs.fugue.co/FG_R00460.html
+FG_R00461:
+  url: https://docs.fugue.co/FG_R00461.html
+FG_R00462:
+  url: https://docs.fugue.co/FG_R00462.html
+FG_R00463:
+  url: https://docs.fugue.co/FG_R00463.html
+FG_R00464:
+  url: https://docs.fugue.co/FG_R00464.html
+FG_R00465:
+  url: https://docs.fugue.co/FG_R00465.html
+FG_R00466:
+  url: https://docs.fugue.co/FG_R00466.html
+FG_R00467:
+  url: https://docs.fugue.co/FG_R00467.html
+FG_R00468:
+  url: https://docs.fugue.co/FG_R00468.html
+FG_R00469:
+  url: https://docs.fugue.co/FG_R00469.html
+FG_R00470:
+  url: https://docs.fugue.co/FG_R00470.html
+FG_R00471:
+  url: https://docs.fugue.co/FG_R00471.html
+FG_R00472:
+  url: https://docs.fugue.co/FG_R00472.html
+FG_R00478:
+  url: https://docs.fugue.co/FG_R00478.html


### PR DESCRIPTION
This is currently a bit hackish; I just added code to check the ID at
the end of the process and inject the link if it's something we have
remediation documentation for.  Longer term it would probably make
sense to move the link into the __rego_metadoc__ blocks in the rego
files, but there is some infrastructure stuff which needs to happen
first.

I decided to leave `rego/rules/remediation.yaml` out of git, which may be the wrong decision... the file is generated (based on rules in the Makefile) using curl, grep, sort, and awk.  This shouldn't be a problem on Linux or macOS, but may be somewhat tricky on Windows.