### PR TITLE
Add Google Analytics to the docs site

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.1.2
-mkdocs-material==7.1.5
+mkdocs-material==7.1.8
 mkdocs-macros-plugin==0.5.5
 mkdocs-redirects==1.0.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,9 @@ extra:
     - icon: fontawesome/solid/envelope
       link: mailto:regula@fugue.co
       name: Email the Regula team
+  analytics:
+    provider: google
+    property: G-83QYJE6Q8C
 plugins:
   - macros
   - search


### PR DESCRIPTION
This PR adds a Google Analytics code to each page of regula.dev. It also upgrades the Material theme to support this.

Followed the format here: https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics