### PR TITLE
[RM-5839] Support template strings in jsonencode

### DIFF
--- a/pkg/loader/tf_test/template-in-jsonencode.json
+++ b/pkg/loader/tf_test/template-in-jsonencode.json
@@ -1,0 +1,23 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.test1": {
+        "_filepath": "tf_test/template-in-jsonencode/main.tf",
+        "_provider": "aws",
+        "_type": "aws_s3_bucket",
+        "bucket": "test1",
+        "id": "aws_s3_bucket.test1"
+      },
+      "aws_s3_bucket_policy.test1": {
+        "_filepath": "tf_test/template-in-jsonencode/main.tf",
+        "_provider": "aws",
+        "_type": "aws_s3_bucket_policy",
+        "bucket": "aws_s3_bucket.test1",
+        "id": "aws_s3_bucket_policy.test1",
+        "policy": "{\"Id\":\"MYBUCKETPOLICY\",\"Statement\":[{\"Action\":\"s3:List*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"aws_s3_bucket.test1\",\"Sid\":\"IPAllow\"}],\"Version\":\"2012-10-17\"}"
+      }
+    }
+  },
+  "filepath": "tf_test/template-in-jsonencode"
+}

--- a/pkg/loader/tf_test/template-in-jsonencode/main.tf
+++ b/pkg/loader/tf_test/template-in-jsonencode/main.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket" "test1" {
+  bucket  = "test1"
+}
+
+resource "aws_s3_bucket_policy" "test1" {
+  bucket = "${aws_s3_bucket.test1.id}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "MYBUCKETPOLICY"
+    Statement = [
+      {
+        Sid       = "IPAllow"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:List*"
+        # Resource =        "*"
+        Resource =        "${aws_s3_bucket.test1.arn}/*"
+      },
+    ]
+  })  
+}


### PR DESCRIPTION
This PR adds support for a common usage of jsonencode:

```hcl
resource "aws_s3_bucket" "test1" {
  bucket  = "test1"
}

resource "aws_s3_bucket_policy" "test1" {
  bucket = "${aws_s3_bucket.test1.id}"
  policy = jsonencode({
    Version = "2012-10-17"
    Id      = "MYBUCKETPOLICY"
    Statement = [
      {
        Sid       = "IPAllow"
        Effect    = "Allow"
        Principal = "*"
        Action    = "s3:List*"
        # Resource =        "*"
        Resource =        "${aws_s3_bucket.test1.arn}/*"
      },
    ]
  })  
}
```

Before this PR, our `tf` loader would render `policy` out to `null` because our method of evaluating most functions does not currently handle resource attributes. This PR adds a special case for `jsonencode` because this usage is so prevalent in the Terraform documentation. We'll follow up with a more complete solution to evaluate functions with resources / attributes in scope in a separate PR.