### PR TITLE
Add make help target, assorted other Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 # Variables #
 #############
 
-BINARY = bin/regula
-INSTALLED_BINARY = /usr/local/bin/regula
 GO_SOURCE = $(shell find cmd pkg -type f -name '*.go') $(shell find cmd pkg -type f -name '*.tmpl')
 CLI_SOURCE = $(GO_SOURCE) $(wildcard cmd/*.txt) go.mod go.sum
 MOCKS = $(wildcard pkg/mocks/*.go)
@@ -22,7 +20,28 @@ NEXT_MINOR = $(shell $(CHANGIE) next minor)
 NEXT_PATCH = $(shell $(CHANGIE) next patch)
 VERSION = $(shell $(CHANGIE) latest)
 
-REMEDIATION_LINKS = rego/rules/remediation.yaml
+# Executables
+GO ?= go
+DOCKER ?= docker
+GOLINT ?= $(GO_BIN_DIR)/golint
+MOCKGEN ?= $(GO_BIN_DIR)/mockgen
+CHANGIE ?= $(GO_BIN_DIR)/changie
+GORELEASER ?= $(GO_BIN_DIR)/goreleaser
+
+# Internal targets
+BINARY = bin/regula
+INSTALLED_BINARY = /usr/local/bin/regula
+REMEDIATION_LINKS = rego/remediation.yaml
+
+YQ = $(DOCKER) run --rm -v $(shell pwd):/workdir mikefarah/yq:4
+
+.PHONY: binary
+binary: ## Build regula binary
+binary: $(BINARY)
+
+# https://gist.github.com/prwhite/8168133#gistcomment-3456785
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##############
 #   Swagger  #
@@ -35,9 +54,10 @@ $(SWAGGER):
 	wget -q -O $@ $(SWAGGER_URL)
 
 .PHONY: swagger_gen
+swagger_gen: ## Regenerate go-swagger bindings
 swagger_gen: $(SWAGGER)
 	mkdir -p pkg/swagger
-	docker run --rm -it \
+	$(DOCKER) run --rm -it \
     	--volume $(shell pwd):/regula \
     	--user $(shell id -u):$(shell id -g) \
     	--workdir /regula \
@@ -48,25 +68,20 @@ swagger_gen: $(SWAGGER)
 #   Tools   #
 #############
 
-GOLINT = $(GO_BIN_DIR)/golint
-MOCKGEN = $(GO_BIN_DIR)/mockgen
-CHANGIE = $(GO_BIN_DIR)/changie
-GORELEASER = $(GO_BIN_DIR)/goreleaser
-YQ = docker run --rm -v $(shell pwd):/workdir mikefarah/yq:4
-
 $(GOLINT):
-	go install golang.org/x/lint/golint
+	$(GO) install golang.org/x/lint/golint
 
 $(MOCKGEN):
-	go install github.com/golang/mock/mockgen@v1.5.0
+	$(GO) install github.com/golang/mock/mockgen@v1.5.0
 
 $(CHANGIE):
-	go install github.com/miniscruff/changie@v0.5.0
+	$(GO) install github.com/miniscruff/changie@v0.5.0
 
 $(GORELEASER):
-	go install github.com/goreleaser/goreleaser@v0.164.0
+	$(GO) install github.com/goreleaser/goreleaser@v0.164.0
 
 .PHONY: install_tools
+install_tools: ## Download and install golint, mockgen, changie, and goreleaser
 install_tools: $(GOLINT) $(MOCKGEN) $(CHANGIE) $(GORELEASER)
 
 ##############
@@ -77,41 +92,48 @@ $(BINARY): $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE) $(REMEDIATION_L
 	$(CLI_BUILD) -v -o $@
 
 $(INSTALLED_BINARY): $(BINARY)
-	cp $(BINARY) $(INSTALLED_BINARY)
+	install -m 0655 $(BINARY) $(INSTALLED_BINARY)
 
 .PHONY: install
+install: ## Install regula
 install: $(INSTALLED_BINARY)
 
 .PHONY: clean
-clean:
+clean: ## Delete generated files
 	rm -f coverage.out
 	rm -f $(BINARY)
 
 .PHONY: test
+test: ## Run test suite
 test:
-	go test -v -cover ./...
+	$(GO) test -v -cover ./...
 
 .PHONY: coverage
-coverage:
-	go test ./... -coverprofile=coverage.out
-	go tool cover -html=coverage.out
+coverage: ## Run coverage analysis
+	$(GO) test ./... -coverprofile=coverage.out
+	$(GO) tool cover -html=coverage.out
 
 .PHONY: lint
-lint:
+lint: ## Run the `go vet` linter
 	$(GOLINT) ./...
-	go vet ./...
+	$(GO) vet ./...
 
 .PHONY: docker
+docker: ## Build Docker container
 docker: $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE)
 	rm -rf dist
 	mkdir -p dist
 	GOOS=linux GOARCH=amd64 $(CLI_BUILD) -v -o dist/regula
 	cp Dockerfile dist
-	cd dist && docker build --tag fugue/regula:dev .
+	cd dist && $(DOCKER) build --tag fugue/regula:dev .
 
 ################################
 #   Remediation documentation  #
 ################################
+
+.PHONY: remediation
+remediation: ## Regenerate remediation links
+remediation: rules/remediation.yaml
 
 $(REMEDIATION_LINKS):
 	curl -s "https://docs.fugue.co/remediation.html" | grep -Eo 'FG_R[0-9]+' | sort -u | awk '{ print $$1 ":\n  url: https://docs.fugue.co/" $$1 ".html" }' > "$@"


### PR DESCRIPTION
 * Adds documentation (the help target)
 * Switches to variables which can be overridden (?= instead of =) for
   some things.
 * Uses new variables to make more things configurable (docker, go)
 * Use install instead of cp for installing binary
 * Make building the binary the default for a plain `make`