### PR TITLE
Add families to rego metadoc

### DIFF
--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -240,16 +240,16 @@ func (rego *RegoMeta) String() string {
 	// Find new imports
 	newImports := []string{}
 	for imp := range rego.Imports {
-    	if _, ok := rego.originalImports[imp]; !ok {
-        	newImports = append(newImports, imp.String())
-    	}
+		if _, ok := rego.originalImports[imp]; !ok {
+			newImports = append(newImports, imp.String())
+		}
 	}
 
 	// Render a list of lines that will be placed below the package name.
 	// This includes all the things that weren't in the original file.
 	belowPackage := []string{}
 	if len(newImports) > 0 {
-    	belowPackage = append(belowPackage, strings.Join(newImports, "\n"))
+		belowPackage = append(belowPackage, strings.Join(newImports, "\n"))
 	}
 	if rego.metadocStartLine < 0 && haveMetadoc {
 		belowPackage = append(belowPackage, metadocString)

--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -47,6 +47,7 @@ type RegoMeta struct {
 	Description string
 	Severity    string
 	Controls    map[string][]string
+	Families    []string
 
 	ResourceType     string // Resource type
 	resourceTypeLine int
@@ -72,6 +73,7 @@ func RegoMetaFromPath(path string) (*RegoMeta, error) {
 type metadocCustom struct {
 	Severity string              `json:"severity"`
 	Controls map[string][]string `json:"controls"`
+	Families []string            `json:"families"`
 }
 
 type metadoc struct {
@@ -184,6 +186,7 @@ func RegoMetaFromString(str string) (*RegoMeta, error) {
 		if metadoc.Custom != nil {
 			rego.Controls = metadoc.Custom.Controls
 			rego.Severity = metadoc.Custom.Severity
+			rego.Families = metadoc.Custom.Families
 		}
 	}
 
@@ -223,6 +226,11 @@ func (rego *RegoMeta) String() string {
 		delete(custom, "controls")
 	} else {
 		custom["controls"] = rego.Controls
+	}
+	if len(rego.Families) == 0 {
+		delete(custom, "families")
+	} else {
+		custom["families"] = rego.Families
 	}
 	if len(custom) == 0 {
 		delete(custom, "custom")

--- a/pkg/regotools/metadoc/metadoc_test.go
+++ b/pkg/regotools/metadoc/metadoc_test.go
@@ -74,7 +74,11 @@ __rego__metadoc__ := {
         "NIST-800-53_vRev4_SC-13"
       ]
     },
-    "severity": "High"
+    "severity": "High",
+    "families": [
+      "MyCustomFamily",
+      "1172ca4f-6d31-4c46-a085-54ff73c6ed27"
+    ]
   },
   "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
   "id": "FG_R00016",
@@ -95,6 +99,10 @@ allow {
 				assert.Equal(t, "EBS volume encryption should be enabled", rego.Title)
 				assert.Equal(t, "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.", rego.Description)
 				assert.Equal(t, "High", rego.Severity)
+				assert.Equal(t, []string{
+					"MyCustomFamily",
+					"1172ca4f-6d31-4c46-a085-54ff73c6ed27",
+				}, rego.Families)
 				assert.Equal(t,
 					map[string][]string{
 						"CIS-AWS_v1.3.0":    {"CIS-AWS_v1.3.0_2.2.1"},
@@ -104,6 +112,7 @@ allow {
 
 				rego.Description = "Updated description"
 				rego.Severity = "Low"
+				rego.Families[1] = "ee1dfd49-a46f-433d-99b9-25805d7e8766"
 				delete(rego.Controls, "CIS-AWS_v1.3.0")
 			},
 			expected: `
@@ -117,6 +126,10 @@ __rego__metadoc__ := {
         "NIST-800-53_vRev4_SC-13"
       ]
     },
+    "families": [
+      "MyCustomFamily",
+      "ee1dfd49-a46f-433d-99b9-25805d7e8766"
+    ],
     "severity": "Low"
   },
   "description": "Updated description",


### PR DESCRIPTION
There are two commits here; the first just "fixes" some indenting.  The second is actually useful; it adds support for families to the custom `__rego_metadoc__` section.