### PR TITLE
Add remediation documentation URLs to JSON output.

### DIFF
--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -219,7 +219,7 @@ func (o RegulaOutput) AggregateByRule() ResultsByRule {
 			RuleName:           results[0].RuleName,
 			RuleSummary:        results[0].RuleSummary,
 			RuleSeverity:       results[0].RuleSeverity,
-			RuleRemediationDoc: getRemediationDoc(results[0].RuleID),
+			RuleRemediationDoc: results[0].RuleRemediationDoc,
 			Results:            results,
 		})
 	}
@@ -256,19 +256,20 @@ func (o RegulaOutput) FailuresByRule() ResultsByRule {
 }
 
 type RuleResult struct {
-	Controls        []string `json:"controls"`
-	Filepath        string   `json:"filepath"`
-	InputType       string   `json:"input_type"`
-	Provider        string   `json:"provider"`
-	ResourceID      string   `json:"resource_id"`
-	ResourceType    string   `json:"resource_type"`
-	RuleDescription string   `json:"rule_description"`
-	RuleID          string   `json:"rule_id"`
-	RuleMessage     string   `json:"rule_message"`
-	RuleName        string   `json:"rule_name"`
-	RuleResult      string   `json:"rule_result"`
-	RuleSeverity    string   `json:"rule_severity"`
-	RuleSummary     string   `json:"rule_summary"`
+	Controls           []string `json:"controls"`
+	Filepath           string   `json:"filepath"`
+	InputType          string   `json:"input_type"`
+	Provider           string   `json:"provider"`
+	ResourceID         string   `json:"resource_id"`
+	ResourceType       string   `json:"resource_type"`
+	RuleDescription    string   `json:"rule_description"`
+	RuleID             string   `json:"rule_id"`
+	RuleMessage        string   `json:"rule_message"`
+	RuleName           string   `json:"rule_name"`
+	RuleResult         string   `json:"rule_result"`
+	RuleSeverity       string   `json:"rule_severity"`
+	RuleSummary        string   `json:"rule_summary"`
+	RuleRemediationDoc string   `json:"rule_remediaion_doc",omitempty`
 	// List of source code locations this rule result pertains to.  The first
 	// element of the list always refers to the most specific source code site,
 	// and further elements indicate modules in which this was included, like
@@ -320,6 +321,7 @@ func ParseRegulaOutput(conf loader.LoadedConfigurations, r rego.Result) (*Regula
 		if err == nil {
 			output.RuleResults[i].SourceLocation = location
 		}
+		output.RuleResults[i].RuleRemediationDoc = getRemediationDoc(result.RuleID)
 	}
 
 	return output, nil


### PR DESCRIPTION
Sample output:

```json
{
    "controls": [
    "CIS-AWS_v1.2.0_4.3",
    "CIS-AWS_v1.3.0_5.3"
  ],
  "filepath": "rego/tests/examples/aws/inputs/tag_all_resources_infra.json",
  "input_type": "tf_plan",
  "provider": "aws",
  "resource_id": "aws_vpc.untagged",
  "resource_type": "aws_vpc",
  "rule_description": "VPC default security group should restrict all traffic. Configuring all VPC default security groups to restrict all traffic encourages least privilege security group development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.",
  "rule_id": "FG_R00089",
  "rule_message": "",
  "rule_name": "tf_aws_vpc_default_security_group",
  "rule_result": "FAIL",
  "rule_severity": "Medium",
  "rule_summary": "VPC default security group should restrict all traffic",
  "rule_remediaion_doc": "https://docs.fugue.co/FG_R00089.html"
}
```

Note the last line.