### PR TITLE
[RM-5867] Use __rego__metadoc__ for provider instead of header

### DIFF
--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -48,6 +48,7 @@ type RegoMeta struct {
 	Severity    string
 	Controls    map[string][]string
 	Families    []string
+	Provider    string
 
 	ResourceType     string // Resource type
 	resourceTypeLine int
@@ -74,6 +75,7 @@ type metadocCustom struct {
 	Severity string              `json:"severity"`
 	Controls map[string][]string `json:"controls"`
 	Families []string            `json:"families"`
+	Provider string              `json:"provider"`
 }
 
 type metadoc struct {
@@ -187,6 +189,7 @@ func RegoMetaFromString(str string) (*RegoMeta, error) {
 			rego.Controls = metadoc.Custom.Controls
 			rego.Severity = metadoc.Custom.Severity
 			rego.Families = metadoc.Custom.Families
+			rego.Provider = metadoc.Custom.Provider
 		}
 	}
 
@@ -231,6 +234,11 @@ func (rego *RegoMeta) String() string {
 		delete(custom, "families")
 	} else {
 		custom["families"] = rego.Families
+	}
+	if len(rego.Provider) == 0 {
+		delete(custom, "provider")
+	} else {
+		custom["provider"] = rego.Provider
 	}
 	if len(custom) == 0 {
 		delete(custom, "custom")

--- a/pkg/regotools/metadoc/metadoc_test.go
+++ b/pkg/regotools/metadoc/metadoc_test.go
@@ -78,7 +78,8 @@ __rego__metadoc__ := {
     "families": [
       "MyCustomFamily",
       "1172ca4f-6d31-4c46-a085-54ff73c6ed27"
-    ]
+    ],
+    "provider": "AWS"
   },
   "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
   "id": "FG_R00016",
@@ -109,11 +110,13 @@ allow {
 						"NIST-800-53_vRev4": {"NIST-800-53_vRev4_SC-13"},
 					},
 					rego.Controls)
+				assert.Equal(t, "AWS", rego.Provider)
 
 				rego.Description = "Updated description"
 				rego.Severity = "Low"
 				rego.Families[1] = "ee1dfd49-a46f-433d-99b9-25805d7e8766"
 				delete(rego.Controls, "CIS-AWS_v1.3.0")
+				rego.Provider = "Azure"
 			},
 			expected: `
 # Copyright 2020 Fugue, Inc.
@@ -130,6 +133,7 @@ __rego__metadoc__ := {
       "MyCustomFamily",
       "ee1dfd49-a46f-433d-99b9-25805d7e8766"
     ],
+    "provider": "Azure",
     "severity": "Low"
   },
   "description": "Updated description",


### PR DESCRIPTION
Basically, instead of something like:

```
# Provider: AWS

__rego__metadoc__ := {
  "id": "FG_R00011",
  "title": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https",
  "description": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https. CloudFront connections should be encrypted during transmission over networks that can be accessed by malicious individuals. A CloudFront distribution should only use HTTPS or Redirect HTTP to HTTPS for communication between viewers and CloudFront.",
  "custom": {
    "severity": "Medium",
    "families": [
      "More rules",
      "e6f9b788-1841-4466-8db7-28d2f08da2ff"
    ]
  }
}
```

With this patch we now prefer something like:

```
__rego__metadoc__ := {
  "id": "FG_R00011",
  "title": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https",
  "description": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https. CloudFront connections should be encrypted during transmission over networks that can be accessed by malicious individuals. A CloudFront distribution should only use HTTPS or Redirect HTTP to HTTPS for communication between viewers and CloudFront.",
  "custom": {
    "severity": "Medium",
    "families": [
      "More rules",
      "e6f9b788-1841-4466-8db7-28d2f08da2ff"
    ],
    "provider": "AWS"
  }
}
```