### PR TITLE
[RM-5973] [RM-5974] [RM-5975] Add CIS AWS v1.4.0 and CIS Google v1.2.0

### DIFF
--- a/rego/rules/cfn/cloudtrail/cloudwatch.rego
+++ b/rego/rules/cfn/cloudtrail/cloudwatch.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.4"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.4"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/cfn/cloudtrail/encryption.rego
+++ b/rego/rules/cfn/cloudtrail/encryption.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.7"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.7"
       ]
     },
     "severity": "High"

--- a/rego/rules/cfn/cloudtrail/s3_access_logging.rego
+++ b/rego/rules/cfn/cloudtrail/s3_access_logging.rego
@@ -24,6 +24,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.6"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.6"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/cfn/cloudtrail/target.rego
+++ b/rego/rules/cfn/cloudtrail/target.rego
@@ -24,6 +24,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.3"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.3"
       ]
     },
     "severity": "Critical"

--- a/rego/rules/cfn/s3/block_public_access.rego
+++ b/rego/rules/cfn/s3/block_public_access.rego
@@ -18,6 +18,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_1.20"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/cfn/s3/https_access.rego
+++ b/rego/rules/cfn/s3/https_access.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_2.1.2"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.2"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/cfn/vpc/default_security_group.rego
+++ b/rego/rules/cfn/vpc/default_security_group.rego
@@ -23,6 +23,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_5.3"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_5.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/cloudtrail/cloudwatch.rego
+++ b/rego/rules/tf/aws/cloudtrail/cloudwatch.rego
@@ -25,6 +25,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.4"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.4"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/cloudtrail/encryption.rego
+++ b/rego/rules/tf/aws/cloudtrail/encryption.rego
@@ -25,6 +25,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.7"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.7"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/cloudtrail/s3_access_logging.rego
+++ b/rego/rules/tf/aws/cloudtrail/s3_access_logging.rego
@@ -26,6 +26,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.6"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.6"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/cloudtrail/target.rego
+++ b/rego/rules/tf/aws/cloudtrail/target.rego
@@ -26,6 +26,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_3.3"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_3.3"
       ]
     },
     "severity": "Critical"

--- a/rego/rules/tf/aws/iam/password_length.rego
+++ b/rego/rules/tf/aws/iam/password_length.rego
@@ -25,6 +25,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_1.8"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_1.8"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/iam/password_reuse.rego
+++ b/rego/rules/tf/aws/iam/password_reuse.rego
@@ -25,6 +25,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_1.9"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_1.9"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/rds/encryption.rego
+++ b/rego/rules/tf/aws/rds/encryption.rego
@@ -20,7 +20,11 @@ import data.fugue
 
 __rego__metadoc__ := {
   "custom": {
-    "controls": {},
+    "controls": {
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.3.1"
+      ]
+    },
     "severity": "High"
   },
   "description": "RDS instances should be encrypted (AWS-managed or customer-managed KMS CMKs). Encrypting your RDS DB instances provides an extra layer of security by securing your data from unauthorized access.",

--- a/rego/rules/tf/aws/s3/block_public_access.rego
+++ b/rego/rules/tf/aws/s3/block_public_access.rego
@@ -23,6 +23,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_1.20"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/aws/s3/https_access.rego
+++ b/rego/rules/tf/aws/s3/https_access.rego
@@ -23,6 +23,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_2.1.2"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.2"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/aws/vpc/default_security_group.rego
+++ b/rego/rules/tf/aws/vpc/default_security_group.rego
@@ -25,6 +25,9 @@ __rego__metadoc__ := {
       ],
       "CIS-AWS_v1.3.0": [
         "CIS-AWS_v1.3.0_5.3"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_5.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/bigquery/no_public_access.rego
+++ b/rego/rules/tf/google/bigquery/no_public_access.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_7.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_7.1"
       ]
     },
     "severity": "Critical"

--- a/rego/rules/tf/google/compute/block_project_ssh_keys.rego
+++ b/rego/rules/tf/google/compute/block_project_ssh_keys.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.3"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/compute/disable_ip_forwarding.rego
+++ b/rego/rules/tf/google/compute/disable_ip_forwarding.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.6"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.6"
       ]
     },
     "severity": "Low"

--- a/rego/rules/tf/google/compute/disable_serial_ports.rego
+++ b/rego/rules/tf/google/compute/disable_serial_ports.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.5"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/compute/disk_encryption.rego
+++ b/rego/rules/tf/google/compute/disk_encryption.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.7"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.7"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/compute/no_default_service_account.rego
+++ b/rego/rules/tf/google/compute/no_default_service_account.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.1"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/compute/no_default_service_account_with_scopes.rego
+++ b/rego/rules/tf/google/compute/no_default_service_account_with_scopes.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.2"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.2"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/compute/no_public_ip.rego
+++ b/rego/rules/tf/google/compute/no_public_ip.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.9"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.9"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/compute/proxy_ssl_policy.rego
+++ b/rego/rules/tf/google/compute/proxy_ssl_policy.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_3.9"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_3.9"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/compute/shielded_vm.rego
+++ b/rego/rules/tf/google/compute/shielded_vm.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_4.8"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_4.8"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/dns/dnssec_enabled.rego
+++ b/rego/rules/tf/google/dns/dnssec_enabled.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_3.3"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_3.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/dns/dnssec_key_signing_key.rego
+++ b/rego/rules/tf/google/dns/dnssec_key_signing_key.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_3.4"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_3.4"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/dns/dnssec_zone_signing_key.rego
+++ b/rego/rules/tf/google/dns/dnssec_zone_signing_key.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_3.5"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_3.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/iam/kms_role_limits.rego
+++ b/rego/rules/tf/google/iam/kms_role_limits.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_1.11"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_1.11"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/iam/no_service_account_roles.rego
+++ b/rego/rules/tf/google/iam/no_service_account_roles.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_1.6"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_1.6"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/iam/service_account_no_admin.rego
+++ b/rego/rules/tf/google/iam/service_account_no_admin.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_1.5"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_1.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/iam/service_account_no_user_keys.rego
+++ b/rego/rules/tf/google/iam/service_account_no_user_keys.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_1.4"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_1.4"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/kms/no_anonymous_access.rego
+++ b/rego/rules/tf/google/kms/no_anonymous_access.rego
@@ -23,6 +23,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_1.9"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_1.9"
       ]
     },
     "severity": "Critical"

--- a/rego/rules/tf/google/logging/audit_config_logtype.rego
+++ b/rego/rules/tf/google/logging/audit_config_logtype.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_2.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_2.1"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/logging/bucket_lock.rego
+++ b/rego/rules/tf/google/logging/bucket_lock.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_2.3"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_2.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/automated_backups.rego
+++ b/rego/rules/tf/google/sql_database/automated_backups.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.7"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.7"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/mysql_no_local_infile.rego
+++ b/rego/rules/tf/google/sql_database/mysql_no_local_infile.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.1.2"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.1.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/no_public_access.rego
+++ b/rego/rules/tf/google/sql_database/no_public_access.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.5"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.5"
       ]
     },
     "severity": "High"

--- a/rego/rules/tf/google/sql_database/no_public_ip.rego
+++ b/rego/rules/tf/google/sql_database/no_public_ip.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.6"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.6"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_disable_log_min_duration.rego
+++ b/rego/rules/tf/google/sql_database/pg_disable_log_min_duration.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.7"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.16"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_checkpoints.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_checkpoints.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.1"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_connections.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_connections.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.2"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.3"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_disconnections.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_disconnections.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.3"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.4"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_lock_waits.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_lock_waits.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.4"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.6"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_min_messages.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_min_messages.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.5"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.13"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/pg_enable_log_temp_files.rego
+++ b/rego/rules/tf/google/sql_database/pg_enable_log_temp_files.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.2.6"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.2.15"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/require_ssl.rego
+++ b/rego/rules/tf/google/sql_database/require_ssl.rego
@@ -21,6 +21,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.4"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.4"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/sql_server_disable_contained_db_auth.rego
+++ b/rego/rules/tf/google/sql_database/sql_server_disable_contained_db_auth.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.3.2"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.3.7"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/sql_database/sql_server_disable_cross_db_ownership.rego
+++ b/rego/rules/tf/google/sql_database/sql_server_disable_cross_db_ownership.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_6.3.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_6.3.2"
       ]
     },
     "severity": "Medium"

--- a/rego/rules/tf/google/storage/not_public.rego
+++ b/rego/rules/tf/google/storage/not_public.rego
@@ -22,6 +22,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_5.1"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_5.1"
       ]
     },
     "severity": "Critical"

--- a/rego/rules/tf/google/storage/uniform_access.rego
+++ b/rego/rules/tf/google/storage/uniform_access.rego
@@ -19,6 +19,9 @@ __rego__metadoc__ := {
     "controls": {
       "CIS-Google_v1.1.0": [
         "CIS-Google_v1.1.0_5.2"
+      ],
+      "CIS-Google_v1.2.0": [
+        "CIS-Google_v1.2.0_5.2"
       ]
     },
     "severity": "Medium"


### PR DESCRIPTION
This PR adds mappings for CIS AWS 1.4.0 and CIS Google 1.2.0 to the existing set of tf and cfn regula rules.