### PR TITLE
Parse metadoc using HuJSON instead of encoding/json.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tailscale/hujson v0.0.0-20210818175511-7360507a6e88
 	github.com/terraform-providers/terraform-provider-aws v0.0.0-20210819222124-f20616dad806
 	github.com/thediveo/enumflag v0.10.1
 	github.com/zclconf/go-cty v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1110,6 +1110,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
+github.com/tailscale/hujson v0.0.0-20210818175511-7360507a6e88 h1:q5Sxx79nhG4xWsYEJBlLdqo1hNhUV31/NhA4qQ1SKAY=
+github.com/tailscale/hujson v0.0.0-20210818175511-7360507a6e88/go.mod h1:iTDXJsA6A2wNNjurgic2rk+is6uzU4U2NLm4T+edr6M=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=

--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -15,11 +15,12 @@
 package metadoc
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
+
+	json "github.com/tailscale/hujson"
 )
 
 // Utility to modify metadata of rego files.

--- a/pkg/regotools/metadoc/metadoc_test.go
+++ b/pkg/regotools/metadoc/metadoc_test.go
@@ -72,7 +72,7 @@ __rego__metadoc__ := {
       ],
       "NIST-800-53_vRev4": [
         "NIST-800-53_vRev4_SC-13"
-      ]
+      ],
     },
     "severity": "High",
     "families": [


### PR DESCRIPTION
[HuJSON](https://github.com/tailscale/hujson) is a fork of encoding/json which allows embedded comments and trailing commas.  The API is compatible so all that is necessary is to import HuJSON instead of encoding/json; as long as the imported name remains the same no further code changes are necessary.