### PR TITLE
Added k8s to input types help text (#217)

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -48,6 +48,7 @@ Input types:
     tf-plan     Terraform plan JSON
     cfn         CloudFormation template in YAML or JSON format
     tf          Terraform directory or file
+    k8s         Kubernetes manifest in YAML format
 `
 const formatDescriptions = `
 Output formats:


### PR DESCRIPTION
This is a small PR To add `k8s` to the help text used by `regula run` and other commands that accept `--input-type` flags.