### PR TITLE
[RM-6152] Switch docker image to use alpine instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM scratch
-WORKDIR /workspace
-ENTRYPOINT [ "/usr/local/bin/regula" ]
-COPY regula /usr/local/bin/regula
+FROM alpine:3.14
+ENV APP_USER=regula
+ENV APP_DIR=/workspace
+RUN adduser -s /bin/true -u 1000 -D -h $APP_DIR $APP_USER
+COPY regula /bin/regula
+USER ${APP_USER}
+WORKDIR ${APP_DIR}
+ENTRYPOINT [ "/bin/regula" ]


### PR DESCRIPTION
This PR is in response to #215. Switching the regula docker image from scratch to Alpine has a negligible impact on size (21.5MB -> 28.5MB) and enables the regula docker image to run in more places.