### PR TITLE
Bump docs dependencies for CVE-2021-40978

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.1.2
-mkdocs-material==7.1.8
-mkdocs-macros-plugin==0.5.5
+mkdocs==1.2.3
+mkdocs-material==7.3.3
+mkdocs-macros-plugin==0.6.0
 mkdocs-redirects==1.0.3


### PR DESCRIPTION
There's a dependabot alert for CVE-2021-40978, which affects the mkdocs dev server. We don't use the dev server outside of development. But, it's good to resolve that alert.