### PR TITLE
Update remediation links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ docker: $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE)
 ################################
 
 .PHONY: remediation
-remediation: ## Regenerate remediation links
-remediation: rules/remediation.yaml
+remediation: ## Generate remediation links
+remediation: rego/remediation.yaml
 
 $(REMEDIATION_LINKS):
 	curl -s "https://docs.fugue.co/remediation.html" | grep -Eo 'FG_R[0-9]+' | sort -u | awk '{ print $$1 ":\n  url: https://docs.fugue.co/" $$1 ".html" }' > "$@"

--- a/rego/remediation.yaml
+++ b/rego/remediation.yaml
@@ -610,3 +610,33 @@ FG_R00472:
   url: https://docs.fugue.co/FG_R00472.html
 FG_R00478:
   url: https://docs.fugue.co/FG_R00478.html
+FG_R00479:
+  url: https://docs.fugue.co/FG_R00479.html
+FG_R00480:
+  url: https://docs.fugue.co/FG_R00480.html
+FG_R00481:
+  url: https://docs.fugue.co/FG_R00481.html
+FG_R00482:
+  url: https://docs.fugue.co/FG_R00482.html
+FG_R00483:
+  url: https://docs.fugue.co/FG_R00483.html
+FG_R00484:
+  url: https://docs.fugue.co/FG_R00484.html
+FG_R00485:
+  url: https://docs.fugue.co/FG_R00485.html
+FG_R00486:
+  url: https://docs.fugue.co/FG_R00486.html
+FG_R00487:
+  url: https://docs.fugue.co/FG_R00487.html
+FG_R00488:
+  url: https://docs.fugue.co/FG_R00488.html
+FG_R00494:
+  url: https://docs.fugue.co/FG_R00494.html
+FG_R00495:
+  url: https://docs.fugue.co/FG_R00495.html
+FG_R00496:
+  url: https://docs.fugue.co/FG_R00496.html
+FG_R00497:
+  url: https://docs.fugue.co/FG_R00497.html
+FG_R00498:
+  url: https://docs.fugue.co/FG_R00498.html


### PR DESCRIPTION
Several new rules have been added to the web site.

I also had to tweak the Makefile a bit since it was referring to the old location; in the future `make rego/remediation.yaml` should work (though you'll likely have to remove the file first since it doesn't have any dependencies to signal that the file needs to be regenerated).