### PR TITLE
Remove deprecated bottle `:unneeded` from homebrew formula

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(CHANGIE):
 	$(GO) install github.com/miniscruff/changie@v0.5.0
 
 $(GORELEASER):
-	$(GO) install github.com/goreleaser/goreleaser@v0.164.0
+	$(GO) install github.com/goreleaser/goreleaser@v0.183.0
 
 .PHONY: install_tools
 install_tools: ## Download and install golint, mockgen, changie, and goreleaser


### PR DESCRIPTION
`brew install` or `brew upgrade` for `regula` currently shows the following:
```sh
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the fugue/regula tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/fugue/homebrew-regula/Formula/regula.rb:9
```

The generation is fixed in https://github.com/goreleaser/goreleaser/pull/2591 and available with GoReleaser v0.183.0.

Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>