### PR TITLE
Support count.index attribute, less verbose

### DIFF
--- a/pkg/regulatf/moduletree.go
+++ b/pkg/regulatf/moduletree.go
@@ -28,6 +28,7 @@ type ResourceMeta struct {
 	Data     bool
 	Type     string
 	Provider string
+	Count    bool
 	Location hcl.Range
 }
 
@@ -260,6 +261,7 @@ func walkResource(v Visitor, moduleName ModuleName, resource *configs.Resource, 
 		Provider: resource.Provider.Type,
 		Type:     resource.Type,
 		Location: resource.DeclRange,
+		Count:    resource.Count != nil,
 	}
 	v.VisitResource(name, resourceMeta)
 


### PR DESCRIPTION
Two small changes:

 -  Support the `count.index` attribute, since it's often used together
    with `count = 0 / 1`.

 -  Make the output less verbose in case there are many errors, these
    are not really helpful to users anyway, assuming the TF is valid.