### PR TITLE
[RM-6215] Use command-specific viper instead of global

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,6 +32,7 @@ import (
 
 func NewInitCommand() *cobra.Command {
 	description := "Create a new Regula configuration file in the current working directory."
+	v := viper.New()
 	cmd := &cobra.Command{
 		Use:   "init [input...]",
 		Short: description,
@@ -41,7 +42,6 @@ func NewInitCommand() *cobra.Command {
 		),
 		RunE: func(cmd *cobra.Command, paths []string) error {
 			configPath := filepath.Join(".", ".regula.yaml")
-			v := viper.New()
 			v.SetConfigType("yaml")
 			v.SetConfigFile(configPath)
 
@@ -111,17 +111,17 @@ func NewInitCommand() *cobra.Command {
 		},
 	}
 
-	addEnvironmentIDFlag(cmd)
-	addExcludeFlag(cmd)
+	addEnvironmentIDFlag(cmd, v)
+	addExcludeFlag(cmd, v)
 	addForceFlag(cmd)
-	addFormatFlag(cmd)
+	addFormatFlag(cmd, v)
 	addIncludeFlag(cmd)
-	addInputTypeFlag(cmd)
-	addNoBuiltInsFlag(cmd)
-	addNoIgnoreFlag(cmd)
-	addOnlyFlag(cmd)
-	addSeverityFlag(cmd)
-	addSyncFlag(cmd)
+	addInputTypeFlag(cmd, v)
+	addNoBuiltInsFlag(cmd, v)
+	addNoIgnoreFlag(cmd, v)
+	addOnlyFlag(cmd, v)
+	addSeverityFlag(cmd, v)
+	addSyncFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -22,9 +22,11 @@ import (
 	"github.com/fugue/regula/pkg/rego"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewREPLCommand() *cobra.Command {
+	v := viper.New()
 	cmd := &cobra.Command{
 		Use:   "repl [paths containing rego or test inputs]",
 		Short: "Start an interactive session for testing rules with Regula",
@@ -64,7 +66,7 @@ func NewREPLCommand() *cobra.Command {
 		},
 	}
 
-	addNoBuiltInsFlag(cmd)
+	addNoBuiltInsFlag(cmd, v)
 	addNoTestInputsFlag(cmd)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd

--- a/cmd/runconfig.go
+++ b/cmd/runconfig.go
@@ -25,26 +25,24 @@ import (
 	"github.com/fugue/regula/pkg/rego"
 	"github.com/fugue/regula/pkg/reporter"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type runConfig struct {
-	configPath   string
-	environmenId string
-	excludes     []string
-	format       reporter.Format
-	includes     []string
-	inputs       []string
-	inputTypes   []loader.InputType
-	noBuiltIns   bool
-	noConfig     bool
-	noIgnore     bool
-	only         []string
-	rootDir      string
-	severity     reporter.Severity
-	sync         bool
-	upload       bool
+	configPath    string
+	environmentId string
+	excludes      []string
+	format        reporter.Format
+	includes      []string
+	inputs        []string
+	inputTypes    []loader.InputType
+	noBuiltIns    bool
+	noConfig      bool
+	noIgnore      bool
+	only          []string
+	rootDir       string
+	severity      reporter.Severity
+	sync          bool
+	upload        bool
 }
 
 func (c *runConfig) Validate() error {
@@ -113,7 +111,7 @@ func (c *runConfig) ResultProcessor() rego.RegoResultProcessor {
 			if err != nil {
 				return err
 			}
-			if err := client.UploadScan(ctx, c.environmenId, *scanView); err != nil {
+			if err := client.UploadScan(ctx, c.environmentId, *scanView); err != nil {
 				return err
 			}
 			reporter, err := reporter.GetReporter(c.format)
@@ -262,19 +260,4 @@ func translatePaths(paths []string, configDir string) (newPaths []string, err er
 	}
 
 	return
-}
-
-// TODO: Since we're using Viper's BindPFlag(), we should just be able to get the
-// value through viper like every other type of flag we use. For some reason, these
-// string slices are always coming back empty if they're not set in the config file.
-func getStringSlice(cmd *cobra.Command, flagName string) ([]string, error) {
-	if cmd.Flags().Changed(flagName) {
-		fromCmd, err := cmd.Flags().GetStringSlice(flagName)
-		if err != nil {
-			return nil, err
-		}
-		return fromCmd, nil
-	}
-
-	return viper.GetStringSlice(flagName), nil
 }

--- a/cmd/showconfigrego.go
+++ b/cmd/showconfigrego.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/fugue/regula/pkg/rego"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewShowConfigCommand() *cobra.Command {
+	v := viper.New()
 	cmd := &cobra.Command{
 		Use:   "config-rego <options>",
 		Short: "Show the generated config rego file",
@@ -50,8 +52,8 @@ func NewShowConfigCommand() *cobra.Command {
 		},
 	}
 
-	addExcludeFlag(cmd)
-	addOnlyFlag(cmd)
+	addExcludeFlag(cmd, v)
+	addOnlyFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/showscanview.go
+++ b/cmd/showscanview.go
@@ -28,6 +28,7 @@ import (
 )
 
 func NewShowScanViewCommand() *cobra.Command {
+	v := viper.New()
 	cmd := &cobra.Command{
 		Use:   "scan-view [file...]",
 		Short: "Show the JSON output being passed to Fugue.",
@@ -38,10 +39,10 @@ func NewShowScanViewCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := loadConfigFile(configPath); err != nil {
+			if err := loadConfigFile(configPath, v); err != nil {
 				return err
 			}
-			if c := viper.ConfigFileUsed(); c != "" {
+			if c := v.ConfigFileUsed(); c != "" {
 				rootDir = filepath.Dir(c)
 			}
 
@@ -50,30 +51,27 @@ func NewShowScanViewCommand() *cobra.Command {
 			}
 
 			// Inputs
-			configFileInputs := viper.GetStringSlice(inputsFlag)
+			configFileInputs := v.GetStringSlice(inputsFlag)
 			inputs, err := translateInputs(args, configFileInputs, rootDir)
 			if err != nil {
 				return err
 			}
 
 			// Enum types
-			inputTypeNames, err := getStringSlice(cmd, inputTypeFlag)
-			if err != nil {
-				return err
-			}
+			inputTypeNames := v.GetStringSlice(inputTypeFlag)
 			inputTypes, err := loader.InputTypesFromStrings(inputTypeNames)
 			if err != nil {
 				return err
 			}
 
 			config := &runConfig{
-				configPath:   configPath,
-				environmenId: viper.GetString(environmentIDFlag),
-				inputs:       inputs,
-				inputTypes:   inputTypes,
-				rootDir:      rootDir,
-				sync:         true,
-				upload:       true,
+				configPath:    configPath,
+				environmentId: v.GetString(environmentIDFlag),
+				inputs:        inputs,
+				inputTypes:    inputTypes,
+				rootDir:       rootDir,
+				sync:          true,
+				upload:        true,
 			}
 			if err := config.Validate(); err != nil {
 				return err
@@ -123,9 +121,9 @@ func NewShowScanViewCommand() *cobra.Command {
 	}
 
 	addConfigFlag(cmd)
-	addEnvironmentIDFlag(cmd)
-	addInputTypeFlag(cmd)
-	addNoIgnoreFlag(cmd)
+	addEnvironmentIDFlag(cmd, v)
+	addInputTypeFlag(cmd, v)
+	addNoIgnoreFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }


### PR DESCRIPTION
This PR replaces the use of the global viper instance with a command-specific one. This was causing a last-write-wins bug where commands were overwriting each other's flags in the global viper instance.