### PR TITLE
[RM-6259] Convert FG_R00073 to simple rule

### DIFF
--- a/rego/rules/tf/aws/cloudfront/http_monitor.rego
+++ b/rego/rules/tf/aws/cloudfront/http_monitor.rego
@@ -27,30 +27,11 @@ __rego__metadoc__ := {
   "title": "CloudFront distributions should be protected by WAFs"
 }
 
-cloudfronts = fugue.resources("aws_cloudfront_distribution")
+resource_type = "aws_cloudfront_distribution"
 
-wafv1_web_acls = fugue.resources("aws_waf_web_acl")
-wafv2_web_acls = fugue.resources("aws_wafv2_web_acl")
+default allow = false
 
-# WAFv1 ACLs are referenced by ID, while WAFv2 ACLs are referenced by ARN
-wafv1_web_acl_ids = {id | id = wafv1_web_acls[_].id}
-wafv2_web_acl_arns = {arn | arn = wafv2_web_acls[_].arn}
-
-has_web_acl(cf) {
-    wafv1_web_acl_ids[cf.web_acl_id]
-} {
-    wafv2_web_acl_arns[cf.web_acl_id]
-}
-
-resource_type = "MULTIPLE"
-
-policy[j] {
-  cf = cloudfronts[_]
-  has_web_acl(cf)
-  j = fugue.allow_resource(cf)
-} {
-  cf = cloudfronts[_]
-  not has_web_acl(cf)
-  j = fugue.deny_resource(cf)
+allow {
+  input.web_acl_id != ""
 }
 


### PR DESCRIPTION
This PR converts `FG_R00073` to a simple rule. The AWS API validates `web_acl_id` on creation:

```
Error: error creating CloudFront Distribution: InvalidWebACLId: Invalid webACL identifier provided foobar
        status code: 400, request id: 00000000-0000-0000-0000-000000000000
```

So, it's unnecessary and out-of-scope for Regula to validate this field. Since we also do not need to inspect any properties on the WAF for this rule, it's enough for us to check that this field is set.