### PR TITLE
[RM-6200] Allow for function ID in permission.function_name field

### DIFF
--- a/rego/lib/aws/lambda/permissions_library.rego
+++ b/rego/lib/aws/lambda/permissions_library.rego
@@ -17,25 +17,30 @@ import data.fugue
 import data.fugue.utils
 
 permissions = fugue.resources("aws_lambda_permission")
+
 functions = fugue.resources("aws_lambda_function")
 
 function_key(func) = ret {
-    ret = sprintf("%s/%s", [utils.provider(func), func.function_name])
+	ret = sprintf("%s/%s", [utils.provider(func), func.function_name])
 }
 
 permission_key(perm) = ret {
-    ret = sprintf("%s/%s", [utils.provider(perm), perm.function_name])
+	func = functions[perm.function_name]
+	ret = function_key(func)
+} else = ret {
+	ret = sprintf("%s/%s", [utils.provider(perm), perm.function_name])
 }
 
 # Obviously functions names are unique so we shouldn't have multiple functions
 # that share a name.  However, this can be the case if e.g. regula doesn't pick
 # up names correctly, so we want to err on the side of caution.
 funcs_by_key := {k: rs |
-  k = function_key(functions[_])
-  rs = [r | r = functions[_]; function_key(r) = k]
+	k = function_key(functions[_])
+	rs = [r | r = functions[_]; function_key(r) = k]
 }
+
 perm_by_key := {k: rs |
-  k = permission_key(permissions[_])
-  rs = [r | r = permissions[_]; permission_key(r) = k]
+	k = permission_key(permissions[_])
+	rs = [r | r = permissions[_]; permission_key(r) = k]
 }
 


### PR DESCRIPTION
This PR resolves an issue where lambda permissions that are related to functions by reference were not getting picked up by our lambda permissions library #200