### PR TITLE
[RM-6309] Match bucket or ID in bucket_policies_for_bucket

### DIFF
--- a/rego/lib/aws/s3/s3_library.rego
+++ b/rego/lib/aws/s3/s3_library.rego
@@ -27,9 +27,19 @@ bucket_policies_for_bucket(bucket) = ret {
     # External
     [pol.policy |
       pol = bucket_policies[_]
-      pol.bucket == bucket.id
+      matches_bucket_or_id(pol.bucket, bucket)
     ]
   )
+}
+
+matches_bucket_or_id(val, bucket) {
+  not is_null(val)
+  val == bucket.bucket
+}
+
+matches_bucket_or_id(val, bucket) {
+  not is_null(val)
+  val == bucket.id
 }
 
 bucket_name_or_id(bucket) = ret {


### PR DESCRIPTION
This PR fixes an issue where bucket policies that are related to buckets by bucket name (rather than by reference) were not getting picked up by `bucket_policies_for_bucket`.
