### PR TITLE
[RM-6258] Support aws_alb resource type

### DIFF
--- a/rego/lib/aws/security_groups/library.rego
+++ b/rego/lib/aws/security_groups/library.rego
@@ -128,6 +128,8 @@ resource_is_load_balancer(resource) {
   resource._type == "aws_elb"
 } {
   resource._type == "aws_lb"
+} {
+  resource._type == "aws_alb"
 }
 
 # Is a resource allowed in a public security group?

--- a/rego/rules/tf/aws/elb/access_log_enabled.rego
+++ b/rego/rules/tf/aws/elb/access_log_enabled.rego
@@ -34,6 +34,10 @@ all_resources[id] = resource {
   elbs[id] = resource
 } {
   lbs[id] = resource
+} {
+  # Check that aws_alb is in the input. Should only be true in regula.
+  fugue.resource_types_v0["aws_alb"]
+  fugue.resources("aws_alb")[id] = resource
 }
 
 access_logs_enabled(obj) {


### PR DESCRIPTION
This PR adds support for the aws_alb resource type to our rules. aws_alb is an alias for aws_lb and is identical in every way except the name.