### PR TITLE
Makefile: unconditionally regenerate links for remediation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,8 @@ docker: $(CLI_SOURCE) $(REGO_LIB_SOURCE) $(REGO_RULES_SOURCE)
 
 .PHONY: remediation
 remediation: ## Generate remediation links
-remediation: rego/remediation.yaml
-
-$(REMEDIATION_LINKS):
-	curl -s "https://docs.fugue.co/remediation.html" | grep -Eo 'FG_R[0-9]+' | sort -u | awk '{ print $$1 ":\n  url: https://docs.fugue.co/" $$1 ".html" }' > "$@"
+remediation:
+	curl -s "https://docs.fugue.co/remediation.html" | grep -Eo 'FG_R[0-9]+' | sort -u | awk '{ print $$1 ":\n  url: https://docs.fugue.co/" $$1 ".html" }' > "rego/remediation.yaml"
 
 #####################
 # Release processes #
@@ -177,11 +175,11 @@ change: $(CHANGIE)
 
 define bump_rule
 .PHONY: bump_$(1)_version
-bump_$(1)_version: $$(CHANGIE)
+bump_$(1)_version: $$(CHANGIE) remediation
 	$$(CHANGIE) batch $(2)
 	$$(CHANGIE) merge
 	$$(YQ) eval --inplace '.extra.version = "$(2)"' ./mkdocs.yml
-	git add changes CHANGELOG.md mkdocs.yml
+	git add changes CHANGELOG.md mkdocs.yml rego/remediation.yaml
 	@echo "Run the following to complete the release:"
 	@echo "    git commit -m 'Bump version to $(2)'"
 	@echo "    git tag -a -F changes/$(2).md $(2)"


### PR DESCRIPTION
This also adds remediation as a dependency for the bump targets so it
is automatically run when creating a new release.  I also removed the
rego/remediation.yaml target, which wasn't really useful since the
file is included in git not regenerated every time.

I have intentionally not updated rego/remediation.yaml to make testing
easier.