### PR TITLE
[RM-6416] Replace cty.NilVal with cty.NullVal

### DIFF
--- a/pkg/loader/tf_test/ternary-mismatch.json
+++ b/pkg/loader/tf_test/ternary-mismatch.json
@@ -1,0 +1,22 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.bar": {
+        "_filepath": "tf_test/ternary-mismatch/main.tf",
+        "_provider": "aws",
+        "_type": "aws_s3_bucket",
+        "bucket": null,
+        "id": "aws_s3_bucket.bar"
+      },
+      "aws_s3_bucket.foo": {
+        "_filepath": "tf_test/ternary-mismatch/main.tf",
+        "_provider": "aws",
+        "_type": "aws_s3_bucket",
+        "bucket": null,
+        "id": "aws_s3_bucket.foo"
+      }
+    }
+  },
+  "filepath": "tf_test/ternary-mismatch"
+}

--- a/pkg/loader/tf_test/ternary-mismatch/main.tf
+++ b/pkg/loader/tf_test/ternary-mismatch/main.tf
@@ -1,0 +1,15 @@
+variable "foo" {
+  type = string
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "foo" {
+  bucket = var.foo ? {"foo": "bar"} : [1]
+}
+
+resource "aws_s3_bucket" "bar" {
+  bucket = var.foo ? {"foo": "bar"} : aws_s3_bucket.foo.bucket
+}

--- a/pkg/regulatf/moduletree.go
+++ b/pkg/regulatf/moduletree.go
@@ -226,7 +226,7 @@ func walkModule(v Visitor, moduleName ModuleName, module *configs.Module) {
 	name := EmptyFullName(moduleName)
 
 	for _, variable := range module.Variables {
-		if variable.Default != cty.NilVal {
+		if !variable.Default.IsNull() {
 			expr := hclsyntax.LiteralValueExpr{
 				Val:      variable.Default,
 				SrcRange: variable.DeclRange,

--- a/pkg/regulatf/regulatf.go
+++ b/pkg/regulatf/regulatf.go
@@ -237,7 +237,7 @@ func (v *Evaluation) evaluate() error {
 		val, diags := expr.Value(&ctx)
 		if diags.HasErrors() {
 			logrus.Debugf("evaluate: error: %s", diags)
-			val = cty.NilVal
+			val = cty.NullVal(val.Type())
 		}
 
 		singleton := SingletonValTree(name.Local, val)

--- a/pkg/regulatf/valtree.go
+++ b/pkg/regulatf/valtree.go
@@ -145,7 +145,7 @@ func ValTreeToValue(tree ValTree) cty.Value {
 			if v, ok := t[i]; ok {
 				arr[i] = ValTreeToValue(v)
 			} else {
-				arr[i] = cty.NilVal
+				arr[i] = cty.NullVal(cty.DynamicPseudoType)
 			}
 		}
 		return cty.TupleVal(arr)

--- a/pkg/regulatf/valtree_test.go
+++ b/pkg/regulatf/valtree_test.go
@@ -13,7 +13,7 @@ func TestValTree(t *testing.T) {
 	assert.Equal(t,
 		cty.ObjectVal(map[string]cty.Value{
 			"menu": cty.TupleVal([]cty.Value{
-				cty.NilVal,
+				cty.NullVal(cty.DynamicPseudoType),
 				cty.ObjectVal(map[string]cty.Value{
 					"name":  cty.StringVal("pizza"),
 					"price": cty.NumberIntVal(10),
@@ -42,7 +42,7 @@ func TestValTree(t *testing.T) {
 	assert.Equal(t,
 		cty.ObjectVal(map[string]cty.Value{
 			"menu": cty.TupleVal([]cty.Value{
-				cty.NilVal,
+				cty.NullVal(cty.DynamicPseudoType),
 				cty.ObjectVal(map[string]cty.Value{
 					"price": cty.NumberIntVal(10),
 				}),


### PR DESCRIPTION
This PR replaces our use of `cty.NilVal` with `cty.NullVal`. The included `ternary-mismatch.json` resulted in a panic from this line:

```
bucket = var.foo ? {"foo": "bar"} : aws_s3_bucket.foo.bucket
```

because the HCL library's error handling for mismatched conditional return types attempts to call a `FriendlyName()` method on each return type. `cty.NilVal.Type()` returns a native `nil` value, which results in a panic.