### PR TITLE
Add waf known bad inputs rule

### DIFF
--- a/rego/rules/tf/aws/waf/known_bad_inputs.rego
+++ b/rego/rules/tf/aws/waf/known_bad_inputs.rego
@@ -21,9 +21,9 @@ __rego__metadoc__ := {
     "controls": {},
     "severity": "Critical"
   },
-  "description": "WAFv2 web ACLs should include the \u2018AWSManagedRulesKnownBadInputsRuleSet\u2019 managed rule group. The \u201cKnown bad inputs\u201d (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the \u201cLog4JRCE\u201d WAFv2 rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the \u201cCore rule set\u201d (AWSManagedRulesCommonRuleSet) is also included, as the \u201cSizeRestrictions_BODY\u201d rule in that managed rule group verifies that the request body size is at most 8 KB.",
+  "description": "The 'Known bad inputs' (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the 'Log4JRCE' WAFv2 rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the 'Core rule set' (AWSManagedRulesCommonRuleSet) is also included, as the 'SizeRestrictions_BODY' rule in that managed rule group verifies that the request body size is at most 8 KB.",
   "id": "FG_R00500",
-  "title": "WAFv2 web ACLs should include the \u2018AWSManagedRulesKnownBadInputsRuleSet\u2019 managed rule group"
+  "title": "WAFv2 web ACLs should include the 'AWSManagedRulesKnownBadInputsRuleSet' managed rule group"
 }
 
 wafsv2 = fugue.resources("aws_wafv2_web_acl")

--- a/rego/rules/tf/aws/waf/known_bad_inputs.rego
+++ b/rego/rules/tf/aws/waf/known_bad_inputs.rego
@@ -1,0 +1,60 @@
+# Copyright 2020-2021 Fugue, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package rules.tf_aws_waf_known_bad_inputs
+
+import data.fugue
+
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {},
+    "severity": "Critical"
+  },
+  "description": "Utilize the AWS WAF AWSManagedRulesKnownBadInputsRuleSetmanaged rule to protect against malicious input. Utilize the AWS WAF AWSManagedRulesKnownBadInputsRuleSetmanaged rule to protect against malicious input.",
+  "id": "FG_R00500",
+  "title": "Utilize the AWS WAF AWSManagedRulesKnownBadInputsRuleSetmanaged rule to protect against malicious input"
+}
+
+wafsv2 = fugue.resources("aws_wafv2_web_acl")
+
+resource_type = "MULTIPLE"
+
+valid_rule_names = {"AWSManagedRulesKnownBadInputsRuleSet"}
+valid_vendor_names = {"AWS"}
+
+is_valid_waf(waf) {
+  managed_statement = waf.rule[_].statement[_].managed_rule_group_statement[_]
+
+  valid_vendor_names[managed_statement.vendor_name]
+  valid_rule_names[managed_statement.name]
+}
+
+policy[j] {
+  fugue.input_type == "tf_runtime"
+  count(wafsv2) == 0
+  j = fugue.missing_resource("aws_wafv2_web_acl")
+}
+
+policy[j] {
+  waf = wafsv2[_]
+  is_valid_waf(waf)
+  j = fugue.allow_resource(waf)
+}
+
+policy[j] {
+  waf = wafsv2[_]
+  not is_valid_waf(waf)
+  j = fugue.deny_resource(waf)
+}
+

--- a/rego/rules/tf/aws/waf/known_bad_inputs.rego
+++ b/rego/rules/tf/aws/waf/known_bad_inputs.rego
@@ -21,7 +21,7 @@ __rego__metadoc__ := {
     "controls": {},
     "severity": "Critical"
   },
-  "description": "The 'Known bad inputs' (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the 'Log4JRCE' WAFv2 rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the 'Core rule set' (AWSManagedRulesCommonRuleSet) is also included, as the 'SizeRestrictions_BODY' rule in that managed rule group verifies that the request body size is at most 8 KB.",
+  "description": "WAFv2 web ACLs should include the 'AWSManagedRulesKnownBadInputsRuleSet' managed rule group. The 'Known bad inputs' (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the 'Log4JRCE' WAFv2 rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the 'Core rule set' (AWSManagedRulesCommonRuleSet) is also included, as the 'SizeRestrictions_BODY' rule in that managed rule group verifies that the request body size is at most 8 KB.",
   "id": "FG_R00500",
   "title": "WAFv2 web ACLs should include the 'AWSManagedRulesKnownBadInputsRuleSet' managed rule group"
 }

--- a/rego/rules/tf/aws/waf/known_bad_inputs.rego
+++ b/rego/rules/tf/aws/waf/known_bad_inputs.rego
@@ -21,7 +21,7 @@ __rego__metadoc__ := {
     "controls": {},
     "severity": "Critical"
   },
-  "description": "WAFv2 web ACLs should include the \u2018AWSManagedRulesKnownBadInputsRuleSet\u2019 managed rule group. The \u201cKnown bad inputs\u201d (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the \u201cLog4JRCE\u201d WAF rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the \u201cCore rule set\u201d (AWSManagedRulesCommonRuleSet) is also included, as the \u201cSizeRestrictions_BODY\u201d rule in that managed rule group verifies that the request body size is at most 8 KB.",
+  "description": "WAFv2 web ACLs should include the \u2018AWSManagedRulesKnownBadInputsRuleSet\u2019 managed rule group. The \u201cKnown bad inputs\u201d (AWSManagedRulesKnownBadInputsRuleSet) managed rule group contains rules that block request patterns that are invalid or known to be associated with vulnerabilities, such as Log4j. Please note that the \u201cLog4JRCE\u201d WAFv2 rule (and many others) only inspects the first 8 KB of the request body, so you may additionally want to ensure that the \u201cCore rule set\u201d (AWSManagedRulesCommonRuleSet) is also included, as the \u201cSizeRestrictions_BODY\u201d rule in that managed rule group verifies that the request body size is at most 8 KB.",
   "id": "FG_R00500",
   "title": "WAFv2 web ACLs should include the \u2018AWSManagedRulesKnownBadInputsRuleSet\u2019 managed rule group"
 }

--- a/rego/rules/tf/azurerm/sql/auditing_retention_90days.rego
+++ b/rego/rules/tf/azurerm/sql/auditing_retention_90days.rego
@@ -29,7 +29,7 @@ __rego__metadoc__ := {
     },
     "severity": "Medium"
   },
-  "description": "Audit Logs can be used to check for anomalies and give insight into suspected breaches or misuse of information and access.",
+  "description": "SQL Server auditing retention should be 90 days or greater. Audit Logs can be used to check for anomalies and give insight into suspected breaches or misuse of information and access.",
   "id": "FG_R00283",
   "title": "SQL Server auditing retention should be 90 days or greater"
 }


### PR DESCRIPTION
## What

Adds a new rule to detect the presence of the `AWSManagedRulesKnownBadInputsRuleSet` AWS rule set for AWS WAF.

Also see https://github.com/LuminalHQ/risk-manager/pull/4014