### PR TITLE
[RM-6462] Require an environment ID for uploads

### DIFF
--- a/cmd/runconfig.go
+++ b/cmd/runconfig.go
@@ -58,7 +58,7 @@ func (c *runConfig) Validate() error {
 			return fmt.Errorf("--sync is required when --upload is specified")
 		}
 		if c.environmentId == "" {
-			return fmt.Errorf("--environment_id is required when --upload is specified")
+			return fmt.Errorf("--environment-id is required when --upload is specified")
 		}
 	}
 

--- a/cmd/runconfig.go
+++ b/cmd/runconfig.go
@@ -57,6 +57,9 @@ func (c *runConfig) Validate() error {
 		if !c.sync {
 			return fmt.Errorf("--sync is required when --upload is specified")
 		}
+		if c.environmentId == "" {
+			return fmt.Errorf("--environment_id is required when --upload is specified")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Attempting to upload a scan without an environment ID results in an HTTP 400 (Bad Request) status. This change requires a value for this field either from the command line or the config file.