### PR TITLE
[RM-6480] Add families to JSON output

### DIFF
--- a/pkg/fugue/customrules.go
+++ b/pkg/fugue/customrules.go
@@ -46,6 +46,7 @@ func processCustomRule(rule *models.CustomRule) (rego.RegoFile, error) {
 	regometa.Controls = map[string][]string{
 		"Custom": {"custom/" + rule.Name},
 	}
+	regometa.Families = rule.Families
 
 	// Only set resource_type if not set explicitly.
 	if regometa.ResourceType == "" {

--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -307,6 +307,7 @@ func (o RegulaReport) FailuresByRule() ResultsByRule {
 
 type RuleResult struct {
 	Controls           []string `json:"controls"`
+	Families           []string `json:"families"`
 	Filepath           string   `json:"filepath"`
 	InputType          string   `json:"input_type"`
 	Provider           string   `json:"provider"`

--- a/rego/lib/fugue/regula.rego
+++ b/rego/lib/fugue/regula.rego
@@ -137,6 +137,7 @@ rule_resource_result(rule, judgement) = ret {
     "rule_description": rule.metadata.description,
     "rule_severity": rule.metadata.severity,
     "controls": rule.metadata.controls,
+    "families": rule.metadata.families,
     "filepath": judgement.filepath,
     "input_type": input_type_internal.input_type,
     "rule_remediation_doc": rule.metadata.rule_remediation_doc,
@@ -181,6 +182,18 @@ controls(custom) = ret {
   ret = set()
 }
 
+families_from_controls(custom) = ret {
+  ret = { f | custom["controls"][f] }
+} else = ret {
+  ret = set()
+}
+
+families_from_families(custom) = ret {
+  ret = { f | f = custom["families"][_] }
+} else = ret {
+  ret = set()
+}
+
 # Transforms high -> High. Assumes input is a single word.
 title_case(str) = ret {
   ret = concat("", [
@@ -199,6 +212,7 @@ rule_metadata(pkg) = ret {
     "summary": object.get(metadoc, "title", ""),
     "severity": title_case(object.get(custom, "severity", "Unknown")),
     "controls": controls(custom),
+    "families": families_from_controls(custom) | families_from_families(custom),
     "rule_remediation_doc": object.get(custom, "rule_remediation_doc", "")
   }
 }

--- a/rego/tests/lib/fugue_regula_report_01_test.rego
+++ b/rego/tests/lib/fugue_regula_report_01_test.rego
@@ -79,6 +79,7 @@ expected_report = {
       "rule_severity": "High",
       "rule_remediation_doc": "https://example.com",
       "controls": {"MOCK_1.2.3"},
+      "families": {"MOCK"},
       "filepath": "",
       "rule_raw_result": true
     },
@@ -96,6 +97,7 @@ expected_report = {
       "rule_severity": "High",
       "rule_remediation_doc": "https://example.com",
       "controls": {"MOCK_1.2.3"},
+      "families": {"MOCK"},
       "filepath": "",
       "rule_raw_result": true
     },
@@ -113,6 +115,7 @@ expected_report = {
       "rule_severity": "High",
       "rule_remediation_doc": "https://example.com",
       "controls": {"MOCK_1.2.3"},
+      "families": {"MOCK"},
       "filepath": "",
       "rule_raw_result": true
     },
@@ -130,6 +133,7 @@ expected_report = {
       "rule_severity": "Unknown",
       "rule_remediation_doc": "",
       "controls": set(),
+      "families": set(),
       "filepath": "",
       "rule_raw_result": false
     },
@@ -147,6 +151,7 @@ expected_report = {
       "rule_severity": "Unknown",
       "rule_remediation_doc": "",
       "controls": set(),
+      "families": set(),
       "filepath": "",
       "rule_raw_result": false
     },
@@ -164,6 +169,7 @@ expected_report = {
       "rule_severity": "Unknown",
       "rule_remediation_doc": "",
       "controls": set(),
+      "families": set(),
       "filepath": "",
       "rule_raw_result": false
     }

--- a/rego/tests/lib/fugue_regula_scan_view_01_test.rego
+++ b/rego/tests/lib/fugue_regula_scan_view_01_test.rego
@@ -113,6 +113,9 @@ expected_scan_view = {
         "controls": {
           "MOCK_1.2.3"
         },
+        "families": {
+          "MOCK"
+        },
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
         "provider": "aws",
@@ -132,6 +135,9 @@ expected_scan_view = {
         "controls": {
           "MOCK_1.2.3"
         },
+        "families": {
+          "MOCK"
+        },
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
         "provider": "aws",
@@ -150,6 +156,9 @@ expected_scan_view = {
       {
         "controls": {
           "MOCK_1.2.3"
+        },
+        "families": {
+          "MOCK"
         },
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
@@ -168,6 +177,7 @@ expected_scan_view = {
       },
       {
         "controls": set(),
+        "families": set(),
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
         "provider": "aws",
@@ -185,6 +195,7 @@ expected_scan_view = {
       },
       {
         "controls": set(),
+        "families": set(),
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
         "provider": "aws",
@@ -202,6 +213,7 @@ expected_scan_view = {
       },
       {
         "controls": set(),
+        "families": set(),
         "filepath": "tests/lib/inputs/volume_encrypted_infra.tf",
         "input_type": "tf",
         "provider": "aws",


### PR DESCRIPTION
This PR adds `families` to Regula's JSON outputs. `families` is a union of compliance families taken from the `custom.families` metadoc section and the keys in the `custom.controls` section.