### PR TITLE
[RM-6363] Fix issue around module detection

### DIFF
--- a/rego/lib/fugue/resource_view/terraform.rego
+++ b/rego/lib/fugue/resource_view/terraform.rego
@@ -128,7 +128,7 @@ configuration_modules_module(path, val) = ret {
   ret := [[], val]
 } else = ret {
   is_object(val)
-  # count(path) % 3 == 2
+  count(path) % 3 == 0
   module := val.module
   all([b | path[i] = k; i % 3 == 1; b := (k == "module_calls")])
   module_path := [k | path[i] = k; i % 3 == 2]
@@ -142,9 +142,9 @@ configuration_modules[module_path] = ret {
 
   # Calculate input variables used in this module.
   vars := {k: ref |
-     filter_refs(val.expressions[k].references) = refs
+     refs := filter_refs(val.expressions[k].references)
      count(refs) == 1
-     ref = refs[0]
+     ref := refs[0]
   }
 
   ret := [vars, module]

--- a/rego/lib/fugue/resource_view/terraform.rego
+++ b/rego/lib/fugue/resource_view/terraform.rego
@@ -116,30 +116,38 @@ planned_values_resources = {id: ret |
   ])
 }
 
+# Paths to the child modules here will have the following shape:
+#
+#     [..., "module_calls", CHILD_NAME, "module"]
+#
+# Just as in `planned_values_module_resources_walk_path`, there are probably
+# some more constraints that we can enforce below.
+configuration_modules_module(path, val) = ret {
+  is_object(val)
+  path == ["root_module"]
+  ret := [[], val]
+} else = ret {
+  is_object(val)
+  # count(path) % 3 == 2
+  module := val.module
+  all([b | path[i] = k; i % 3 == 1; b := (k == "module_calls")])
+  module_path := [k | path[i] = k; i % 3 == 2]
+  ret := [module_path, module]
+}
+
 # Grab all modules inside the `configuration` section.
 configuration_modules[module_path] = ret {
   walk(input.configuration, [path, val])
-  # Paths to the child modules here will have the following shape:
-  #
-  #     [..., "module_calls", CHILD_NAME, "module"]
-  #
-  # Just as in `planned_values_module_resources_walk_path`, there are probably
-  # some more constraints that we can enforce below.
-  is_object(val)
-  module = val[module_name]
-  is_object(module)
-  _ = module.resources
-  all([b | path[i] = k; i % 3 == 1; b := (k == "module_calls")])
-  module_path = [k | path[i] = k; i % 3 == 2]
+  [module_path, module] = configuration_modules_module(path, val)
 
   # Calculate input variables used in this module.
-  vars = {k: ref |
+  vars := {k: ref |
      filter_refs(val.expressions[k].references) = refs
      count(refs) == 1
      ref = refs[0]
   }
 
-  ret = [vars, module]
+  ret := [vars, module]
 }
 
 # Calculate outputs into a globally qualified map.

--- a/rego/tests/lib/fugue_resource_view_issue256_test.rego
+++ b/rego/tests/lib/fugue_resource_view_issue256_test.rego
@@ -1,0 +1,45 @@
+# Copyright 2020-2022 Fugue, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package fugue.test_resource_view_issue256
+
+import data.fugue.resource_view.terraform
+
+# See <https://github.com/fugue/regula/issues/256>.
+test_resource_view_issue256 {
+	# We don't care too much about the exact representation, that is tested
+	# elsewhere, we just want to ensure this doesn't crash.
+	cms = terraform.configuration_modules with input as problematic_input
+	count(cms) == 2
+}
+
+problematic_input = {
+	"terraform_version": "0.12.1",
+	"configuration": {
+		"root_module": {
+			"module_calls": {
+				"resources": {
+					"for_each_expression": {
+						"references": [
+							"var.api_definition_list"
+						],
+						"resources": {}
+					},
+					"module": {
+						"resources": {}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR tightens up the rules around how we detect modules when using
the terraform plan input, fixing an issue where we would detect two different
blobs of JSON as a module, which leads to the issue described in #256.