### PR TITLE
Docs: Add Regula and Fugue page

### DIFF
--- a/docs/src/fugue.md
+++ b/docs/src/fugue.md
@@ -1,0 +1,31 @@
+# Regula and Fugue
+
+Regula can be used in conjunction with [Fugue](https://www.fugue.co) to ensure infrastructure as code (IaC) is secure and compliant by enforcing the same policy as code across the entire development lifecycle.
+
+## Setting up a Fugue IaC repository environment
+
+To set up a repository environment, see the [Fugue docs](https://docs.fugue.co/setup-repository.html).
+
+## Syncing rules and families from Fugue
+
+Using [`regula run`](usage.md#run) with the `--sync` flag instructs Regula to evaluate your IaC templates using the rules and families enabled for the associated Fugue repository environment. The rules that are applied to your IaC are determined by the compliance families you selected for the environment.
+
+The Fugue repository environment is specified in the `.regula.yaml` configuration file, which is generated when you execute [`regula init --environment-id <environment_id>`](usage.md#init) (see the [Fugue docs](https://docs.fugue.co/setup-repository.html#step-5-kicking-off-a-scan)).
+
+To run Regula locally with synced rules:
+
+```
+regula run --sync
+```
+
+To run Regula locally with synced rules and _also_ send Regula's results to Fugue:
+
+```
+regula run --sync --upload
+```
+
+Be aware that `--sync` overrides other flags that would select rules. For instance, if you use `--sync`, you cannot also use the `--only` flag to select only a single rule, and you cannot use `--include` or `--exclude` to include/exclude other directories of rules. `--sync` ensures that Regula applies the rules configured in your Fugue repository environment.
+
+## Syncing waivers from Fugue
+
+Waivers are not currently synced from Fugue. This support will be added in a future release.

--- a/docs/src/report.md
+++ b/docs/src/report.md
@@ -10,6 +10,10 @@ Here's a snippet of test results from a Regula JSON report:
         "CIS-Azure_v1.1.0_6.4",
         "CIS-Azure_v1.3.0_6.4"
       ],
+      "families": [
+        "CIS-Azure_v1.1.0",
+        "CIS-Azure_v1.3.0"
+      ],
       "filepath": "dev_network/main.tf",
       "input_type": "tf",
       "provider": "azurerm",
@@ -37,6 +41,10 @@ Here's a snippet of test results from a Regula JSON report:
         "CIS-Azure_v1.1.0_6.2",
         "CIS-Azure_v1.3.0_6.2"
       ],
+      "families": [
+        "CIS-Azure_v1.1.0",
+        "CIS-Azure_v1.3.0"
+      ],
       "filepath": "dev_network/main.tf",
       "input_type": "tf",
       "provider": "azurerm",
@@ -63,6 +71,10 @@ Here's a snippet of test results from a Regula JSON report:
       "controls": [
         "CIS-Azure_v1.1.0_3.1",
         "CIS-Azure_v1.3.0_3.1"
+      ],
+      "families": [
+        "CIS-Azure_v1.1.0",
+        "CIS-Azure_v1.3.0"
       ],
       "filepath": "dev_network/main.tf",
       "input_type": "tf",
@@ -130,6 +142,7 @@ The `summary` block contains a breakdown of the `filepaths` (CloudFormation temp
 Each rule result in the JSON report lists the following attributes:
 
 - `controls`: Compliance controls mapped to the rule
+- `families`: Compliance families associated with the rule
 - `filepath`: Filepath of the evaluated Terraform HCL file, Terraform JSON plan, CloudFormation template, Kubernetes manifest, or ARM template (_in preview_)
 - `input_type`: `tf` (Terraform HCL), `tf_plan` (Terraform JSON plan), `cfn` (CloudFormation), `k8s` (Kubernetes), `arm` (Azure Resource Manager JSON; _in preview_)
 - `provider`: `aws`, `azurerm`, `google`, `kubernetes`, `arm`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - "rules.md"
   - "report.md"
   - "configuration.md"
+  - "fugue.md"
   - Integrations:
       - "integrations/conftest.md"
       - "integrations/gh-actions.md"


### PR DESCRIPTION
This adds a page that explains how to use Regula with Fugue.

Also documents `families` in the JSON report output.