### PR TITLE
change table reporter column disposition

### DIFF
--- a/pkg/reporter/table.go
+++ b/pkg/reporter/table.go
@@ -65,14 +65,14 @@ func TableReporter(o *RegulaReport) (string, error) {
 	table := simpletable.New()
 	table.Header = &simpletable.Header{
 		Cells: []*simpletable.Cell{
+			{Align: simpletable.AlignCenter, Text: "Result"},
 			{Align: simpletable.AlignCenter, Text: "Resource"},
+			{Align: simpletable.AlignCenter, Text: "Severity"},
 			{Align: simpletable.AlignCenter, Text: "Type"},
 			{Align: simpletable.AlignCenter, Text: "Filepath"},
-			{Align: simpletable.AlignCenter, Text: "Severity"},
 			{Align: simpletable.AlignCenter, Text: "Rule ID"},
 			{Align: simpletable.AlignCenter, Text: "Rule Name"},
 			{Align: simpletable.AlignCenter, Text: "Message"},
-			{Align: simpletable.AlignCenter, Text: "Result"},
 		},
 	}
 	for _, row := range tableData {
@@ -80,14 +80,14 @@ func TableReporter(o *RegulaReport) (string, error) {
 	}
 	table.Footer = &simpletable.Footer{
 		Cells: []*simpletable.Cell{
-			{},
-			{},
-			{},
-			{},
-			{},
-			{},
-			{Align: simpletable.AlignRight, Text: "Overall"},
 			{Align: simpletable.AlignLeft, Text: colorizeResult(overall)},
+			{Align: simpletable.AlignLeft, Text: "Overall"},
+			{},
+			{},
+			{},
+			{},
+			{},
+			{},
 		},
 	}
 
@@ -108,14 +108,14 @@ type TableRow struct {
 
 func (r TableRow) toCell() []*simpletable.Cell {
 	return []*simpletable.Cell{
+		{Text: r.Result},
 		{Text: r.Resource},
+		{Text: r.Severity},
 		{Text: r.Type},
 		{Text: r.Filepath},
-		{Text: r.Severity},
 		{Text: r.RuleID},
 		{Text: r.RuleName},
 		{Text: r.Message},
-		{Text: r.Result},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Fabiano Graças <fabiano.gracas@faro.com>

Hi guys, we have started to use regula as part of our pipelines, although regula table format delivers nice content It delivers also a wide-sized table, in our pipeline, the disposition of the columns would be nicer with this change. which would look like more to a unit test table results.

The change consists in bringing the result and severity to the very beginning of the table in order to see them first.

before:
![Screenshot 2022-02-02 at 20 23 31](https://user-images.githubusercontent.com/9274235/152227626-1ecfb70d-f7aa-4574-b772-9397e4a406e4.png)

after:
![Screenshot 2022-02-02 at 20 23 14](https://user-images.githubusercontent.com/9274235/152228009-da05c4ad-d6cc-4867-bc64-38331927b634.png)

my best regards,

Fabiano
