### PR TITLE
Add support for valueless tags

### DIFF
--- a/pkg/loader/tf_test/tags.json
+++ b/pkg/loader/tf_test/tags.json
@@ -56,6 +56,45 @@
           "Stage": "Prod"
         }
       },
+      "google_compute_instance.default": {
+        "_filepath": "tf_test/tags/main.tf",
+        "_provider": "google",
+        "_tags": {
+          "bar": null,
+          "foo": null
+        },
+        "_type": "google_compute_instance",
+        "boot_disk": [
+          {
+            "initialize_params": [
+              {
+                "image": "debian-cloud/debian-9"
+              }
+            ]
+          }
+        ],
+        "id": "google_compute_instance.default",
+        "machine_type": "e2-medium",
+        "name": "test",
+        "network_interface": [
+          {
+            "access_config": [
+              {}
+            ],
+            "network": "default"
+          }
+        ],
+        "scratch_disk": [
+          {
+            "interface": "SCSI"
+          }
+        ],
+        "tags": [
+          "foo",
+          "bar"
+        ],
+        "zone": "us-central1-a"
+      },
       "google_storage_bucket.example": {
         "_filepath": "tf_test/tags/main.tf",
         "_provider": "google",

--- a/pkg/loader/tf_test/tags/main.tf
+++ b/pkg/loader/tf_test/tags/main.tf
@@ -62,3 +62,29 @@ resource "google_storage_bucket" "example" {
     Stage = "Prod"
   }
 }
+
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+}

--- a/pkg/loader/tf_test/vars.json
+++ b/pkg/loader/tf_test/vars.json
@@ -6,7 +6,8 @@
         "_filepath": "tf_test/vars/main.tf",
         "_provider": "aws",
         "_tags": {
-          "department": "engineering"
+          "department": "engineering",
+          "environment": null
         },
         "_type": "aws_s3_bucket",
         "id": "aws_s3_bucket.main",

--- a/pkg/regulatf/regulatf.go
+++ b/pkg/regulatf/regulatf.go
@@ -2,8 +2,6 @@
 package regulatf
 
 import (
-	"strings"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -305,57 +303,4 @@ func (v *Evaluation) Location(resourceKey string) []hcl.Range {
 		}
 	}
 	return ranges
-}
-
-func PopulateTags(resource interface{}) {
-	resourceObj := map[string]interface{}{}
-	if obj, ok := resource.(map[string]interface{}); ok {
-		resourceObj = obj
-	}
-
-	tagObj := map[string]interface{}{}
-
-	if typeStr, ok := resourceObj["_type"].(string); ok {
-    	if typeStr == "aws_autoscaling_group" {
-        	if arr, ok := resourceObj["tag"].([]interface{}); ok {
-            	for i := range(arr) {
-                	if obj, ok := arr[i].(map[string]interface{}); ok {
-                    	if key, ok := obj["key"].(string); ok {
-                        	if value, ok := obj["value"]; ok {
-                            	tagObj[key] = value
-                        	}
-                    	}
-                	}
-            	}
-        	}
-    	}
-	}
-
-	if providerStr, ok := resourceObj["_provider"].(string); ok {
-		if provider := strings.SplitN(providerStr, ".", 2); len(provider) > 0 {
-			switch provider[0] {
-			case "google":
-				if tags, ok := resourceObj["labels"].(map[string]interface{}); ok {
-    				for k, v := range tags {
-        				tagObj[k] = v
-    				}
-				}
-			default:
-				if tags, ok := resourceObj["tags"].(map[string]interface{}); ok {
-    				for k, v := range tags {
-        				tagObj[k] = v
-    				}
-				}
-			}
-		}
-	}
-
-	tags := map[string]string{}
-	for k, v := range tagObj {
-		if str, ok := v.(string); ok {
-			tags[k] = str
-		}
-	}
-
-	resourceObj["_tags"] = tags
 }

--- a/pkg/regulatf/tags.go
+++ b/pkg/regulatf/tags.go
@@ -1,0 +1,68 @@
+package regulatf
+
+import (
+	"strings"
+)
+
+func PopulateTags(resource interface{}) {
+	resourceObj := map[string]interface{}{}
+	if obj, ok := resource.(map[string]interface{}); ok {
+		resourceObj = obj
+	}
+
+	tagObj := map[string]interface{}{}
+
+	if typeStr, ok := resourceObj["_type"].(string); ok {
+		if typeStr == "aws_autoscaling_group" {
+			if arr, ok := resourceObj["tag"].([]interface{}); ok {
+				for i := range arr {
+					if obj, ok := arr[i].(map[string]interface{}); ok {
+						if key, ok := obj["key"].(string); ok {
+							if value, ok := obj["value"]; ok {
+								tagObj[key] = value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if providerStr, ok := resourceObj["_provider"].(string); ok {
+		if provider := strings.SplitN(providerStr, ".", 2); len(provider) > 0 {
+			switch provider[0] {
+			case "google":
+				if tags, ok := resourceObj["labels"].(map[string]interface{}); ok {
+					for k, v := range tags {
+						tagObj[k] = v
+					}
+				}
+				if tags, ok := resourceObj["tags"].([]interface{}); ok {
+					for _, key := range tags {
+						if str, ok := key.(string); ok {
+							tagObj[str] = nil
+						}
+					}
+				}
+			default:
+				if tags, ok := resourceObj["tags"].(map[string]interface{}); ok {
+					for k, v := range tags {
+						tagObj[k] = v
+					}
+				}
+			}
+		}
+	}
+
+	// Keep only string and nil tags
+	tags := map[string]interface{}{}
+	for k, v := range tagObj {
+		if str, ok := v.(string); ok {
+			tags[k] = str
+		} else if v == nil {
+			tags[k] = nil
+		}
+	}
+
+	resourceObj["_tags"] = tags
+}

--- a/pkg/reporter/base.go
+++ b/pkg/reporter/base.go
@@ -308,23 +308,23 @@ func (o RegulaReport) FailuresByRule() ResultsByRule {
 }
 
 type RuleResult struct {
-	Controls           []string          `json:"controls"`
-	Families           []string          `json:"families"`
-	Filepath           string            `json:"filepath"`
-	InputType          string            `json:"input_type"`
-	Provider           string            `json:"provider"`
-	ResourceID         string            `json:"resource_id"`
-	ResourceType       string            `json:"resource_type"`
-	ResourceTags       map[string]string `json:"resource_tags"`
-	RuleDescription    string            `json:"rule_description"`
-	RuleID             string            `json:"rule_id"`
-	RuleMessage        string            `json:"rule_message"`
-	RuleName           string            `json:"rule_name"`
-	RuleRawResult      bool              `json:"rule_raw_result"`
-	RuleRemediationDoc string            `json:"rule_remediation_doc,omitempty"`
-	RuleResult         string            `json:"rule_result"`
-	RuleSeverity       string            `json:"rule_severity"`
-	RuleSummary        string            `json:"rule_summary"`
+	Controls           []string               `json:"controls"`
+	Families           []string               `json:"families"`
+	Filepath           string                 `json:"filepath"`
+	InputType          string                 `json:"input_type"`
+	Provider           string                 `json:"provider"`
+	ResourceID         string                 `json:"resource_id"`
+	ResourceType       string                 `json:"resource_type"`
+	ResourceTags       map[string]interface{} `json:"resource_tags"`
+	RuleDescription    string                 `json:"rule_description"`
+	RuleID             string                 `json:"rule_id"`
+	RuleMessage        string                 `json:"rule_message"`
+	RuleName           string                 `json:"rule_name"`
+	RuleRawResult      bool                   `json:"rule_raw_result"`
+	RuleRemediationDoc string                 `json:"rule_remediation_doc,omitempty"`
+	RuleResult         string                 `json:"rule_result"`
+	RuleSeverity       string                 `json:"rule_severity"`
+	RuleSummary        string                 `json:"rule_summary"`
 	// List of source code locations this rule result pertains to.  The first
 	// element of the list always refers to the most specific source code site,
 	// and further elements indicate modules in which this was included, like

--- a/rego/lib/fugue/resource_view/tags.rego
+++ b/rego/lib/fugue/resource_view/tags.rego
@@ -23,7 +23,7 @@ get_from_object(resource, field) = ret {
   ret := {k: v |
     v := tags[k]
     is_string(k)
-    is_string(v)
+    is_tag_value(v)
   }
 } else = ret {
   ret := {}
@@ -39,10 +39,28 @@ get_from_list(resource, field, key_field, value_field) = ret {
     vs := [tag[value_field] |
       tag := tags[_]
       tag[key_field] == k
-      is_string(tag[value_field])
+      is_tag_value(tag[value_field])
     ]
     v := concat(";", vs)
   }
 } else = ret {
   ret := {}
+}
+
+# Get tags (without values) from a resource.  Values are set to null.
+get_from_key_list(resource, field) = ret {
+  tags := object.get(resource, field, [])
+  ret := {k: null |
+    k := tags[_]
+    is_string(k)
+  }
+} else = ret {
+  ret := {}
+}
+
+# Check that a tag value is valid (string or null)
+is_tag_value(x) {
+  is_string(x)
+} {
+  is_null(x)
 }

--- a/rego/lib/fugue/resource_view/terraform.rego
+++ b/rego/lib/fugue/resource_view/terraform.rego
@@ -328,7 +328,10 @@ resource_tags(resource) = ret {
 } else = ret {
   # Google provider: use `labels`
   split(resource._provider, ".")[0] == "google"
-  ret := tags_lib.get_from_object(resource, "labels")
+  ret := object.union(
+    tags_lib.get_from_object(resource, "labels"),
+    tags_lib.get_from_key_list(resource, "tags"),
+  )
 } else = ret {
   # Other providers (azurerm, ?): look in `tags`.
   ret := tags_lib.get_from_object(resource, "tags")

--- a/rego/tests/lib/fugue_resource_view_07_test.rego
+++ b/rego/tests/lib/fugue_resource_view_07_test.rego
@@ -24,4 +24,13 @@ test_resource_view_07 {
   asg := resource_view_07_infra_json.mock_resources[_]
   asg._type == "aws_autoscaling_group"
   asg._tags.Stage == "Dev"
+
+  google_storage_bucket := resource_view_07_infra_json.mock_resources[_]
+  google_storage_bucket._type == "google_storage_bucket"
+  google_storage_bucket._tags.Stage == "Prod"
+
+  google_compute_instance := resource_view_07_infra_json.mock_resources[_]
+  google_compute_instance._type == "google_compute_instance"
+  google_compute_instance._tags.foo == null
+  google_compute_instance._tags.bar == null
 }

--- a/rego/tests/lib/inputs/resource_view_07_infra.json
+++ b/rego/tests/lib/inputs/resource_view_07_infra.json
@@ -112,6 +112,97 @@
               "Stage": "Prod"
             }
           }
+        },
+        {
+          "address": "google_compute_instance.default",
+          "mode": "managed",
+          "type": "google_compute_instance",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 6,
+          "values": {
+            "advanced_machine_features": [],
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "disk_encryption_key_raw": null,
+                "initialize_params": [
+                  {
+                    "image": "debian-cloud/debian-9"
+                  }
+                ],
+                "mode": "READ_WRITE"
+              }
+            ],
+            "can_ip_forward": false,
+            "deletion_protection": false,
+            "description": null,
+            "desired_status": null,
+            "enable_display": null,
+            "hostname": null,
+            "labels": null,
+            "machine_type": "e2-medium",
+            "metadata": null,
+            "metadata_startup_script": null,
+            "name": "test",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "public_ptr_domain_name": null
+                  }
+                ],
+                "alias_ip_range": [],
+                "ipv6_access_config": [],
+                "network": "default",
+                "nic_type": null,
+                "queue_count": null
+              }
+            ],
+            "resource_policies": null,
+            "scratch_disk": [
+              {
+                "interface": "SCSI"
+              }
+            ],
+            "service_account": [],
+            "shielded_instance_config": [],
+            "tags": [
+              "bar",
+              "foo"
+            ],
+            "timeouts": null,
+            "zone": "us-central1-a"
+          }
+        },
+        {
+          "address": "google_storage_bucket.example",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "example",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "cors": [],
+            "default_event_based_hold": null,
+            "encryption": [],
+            "force_destroy": false,
+            "labels": {
+              "Stage": "Prod"
+            },
+            "lifecycle_rule": [],
+            "location": "US",
+            "logging": [],
+            "name": "example",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "timeouts": null,
+            "versioning": [],
+            "website": []
+          }
         }
       ]
     }
@@ -316,6 +407,182 @@
           "website_endpoint": true
         }
       }
+    },
+    {
+      "address": "google_compute_instance.default",
+      "mode": "managed",
+      "type": "google_compute_instance",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "advanced_machine_features": [],
+          "allow_stopping_for_update": null,
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "disk_encryption_key_raw": null,
+              "initialize_params": [
+                {
+                  "image": "debian-cloud/debian-9"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "can_ip_forward": false,
+          "deletion_protection": false,
+          "description": null,
+          "desired_status": null,
+          "enable_display": null,
+          "hostname": null,
+          "labels": null,
+          "machine_type": "e2-medium",
+          "metadata": null,
+          "metadata_startup_script": null,
+          "name": "test",
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "public_ptr_domain_name": null
+                }
+              ],
+              "alias_ip_range": [],
+              "ipv6_access_config": [],
+              "network": "default",
+              "nic_type": null,
+              "queue_count": null
+            }
+          ],
+          "resource_policies": null,
+          "scratch_disk": [
+            {
+              "interface": "SCSI"
+            }
+          ],
+          "service_account": [],
+          "shielded_instance_config": [],
+          "tags": [
+            "bar",
+            "foo"
+          ],
+          "timeouts": null,
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "advanced_machine_features": [],
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "device_name": true,
+              "disk_encryption_key_sha256": true,
+              "initialize_params": [
+                {
+                  "labels": true,
+                  "size": true,
+                  "type": true
+                }
+              ],
+              "kms_key_self_link": true,
+              "source": true
+            }
+          ],
+          "confidential_instance_config": true,
+          "cpu_platform": true,
+          "current_status": true,
+          "guest_accelerator": true,
+          "id": true,
+          "instance_id": true,
+          "label_fingerprint": true,
+          "metadata_fingerprint": true,
+          "min_cpu_platform": true,
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "nat_ip": true,
+                  "network_tier": true
+                }
+              ],
+              "alias_ip_range": [],
+              "ipv6_access_config": [],
+              "ipv6_access_type": true,
+              "name": true,
+              "network_ip": true,
+              "stack_type": true,
+              "subnetwork": true,
+              "subnetwork_project": true
+            }
+          ],
+          "project": true,
+          "reservation_affinity": true,
+          "scheduling": true,
+          "scratch_disk": [
+            {}
+          ],
+          "self_link": true,
+          "service_account": [],
+          "shielded_instance_config": [],
+          "tags": [
+            false,
+            false
+          ],
+          "tags_fingerprint": true
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket.example",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "example",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cors": [],
+          "default_event_based_hold": null,
+          "encryption": [],
+          "force_destroy": false,
+          "labels": {
+            "Stage": "Prod"
+          },
+          "lifecycle_rule": [],
+          "location": "US",
+          "logging": [],
+          "name": "example",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "timeouts": null,
+          "versioning": [],
+          "website": []
+        },
+        "after_unknown": {
+          "cors": [],
+          "encryption": [],
+          "id": true,
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "retention_policy": [],
+          "self_link": true,
+          "uniform_bucket_level_access": true,
+          "url": true,
+          "versioning": [],
+          "website": []
+        }
+      }
     }
   ],
   "configuration": {
@@ -327,6 +594,9 @@
             "constant_value": "us-west-2"
           }
         }
+      },
+      "google": {
+        "name": "google"
       }
     },
     "root_module": {
@@ -413,6 +683,80 @@
               "constant_value": {
                 "Stage": "Prod"
               }
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_compute_instance.default",
+          "mode": "managed",
+          "type": "google_compute_instance",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "boot_disk": [
+              {
+                "initialize_params": [
+                  {
+                    "image": {
+                      "constant_value": "debian-cloud/debian-9"
+                    }
+                  }
+                ]
+              }
+            ],
+            "machine_type": {
+              "constant_value": "e2-medium"
+            },
+            "name": {
+              "constant_value": "test"
+            },
+            "network_interface": [
+              {
+                "access_config": [
+                  {}
+                ],
+                "network": {
+                  "constant_value": "default"
+                }
+              }
+            ],
+            "scratch_disk": [
+              {
+                "interface": {
+                  "constant_value": "SCSI"
+                }
+              }
+            ],
+            "tags": {
+              "constant_value": [
+                "foo",
+                "bar"
+              ]
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "schema_version": 6
+        },
+        {
+          "address": "google_storage_bucket.example",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "example",
+          "provider_config_key": "google",
+          "expressions": {
+            "labels": {
+              "constant_value": {
+                "Stage": "Prod"
+              }
+            },
+            "location": {
+              "constant_value": "US"
+            },
+            "name": {
+              "constant_value": "example"
             }
           },
           "schema_version": 0

--- a/rego/tests/lib/inputs/resource_view_07_infra.tf
+++ b/rego/tests/lib/inputs/resource_view_07_infra.tf
@@ -47,3 +47,41 @@ resource "aws_launch_template" "example" {
   image_id      = "ami-1a2b3c"
   instance_type = "t2.micro"
 }
+
+provider "google" {
+}
+
+resource "google_storage_bucket" "example" {
+  provider = google
+  name     = "example"
+  location = "US"
+  labels   = {
+    Stage = "Prod"
+  }
+}
+
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+}

--- a/rego/tests/lib/inputs/resource_view_07_infra_json.rego
+++ b/rego/tests/lib/inputs/resource_view_07_infra_json.rego
@@ -29,6 +29,9 @@ mock_config := {
           }
         },
         "name": "aws"
+      },
+      "google": {
+        "name": "google"
       }
     },
     "root_module": {
@@ -118,6 +121,80 @@ mock_config := {
           "provider_config_key": "aws",
           "schema_version": 0,
           "type": "aws_s3_bucket"
+        },
+        {
+          "address": "google_compute_instance.default",
+          "expressions": {
+            "boot_disk": [
+              {
+                "initialize_params": [
+                  {
+                    "image": {
+                      "constant_value": "debian-cloud/debian-9"
+                    }
+                  }
+                ]
+              }
+            ],
+            "machine_type": {
+              "constant_value": "e2-medium"
+            },
+            "name": {
+              "constant_value": "test"
+            },
+            "network_interface": [
+              {
+                "access_config": [
+                  {}
+                ],
+                "network": {
+                  "constant_value": "default"
+                }
+              }
+            ],
+            "scratch_disk": [
+              {
+                "interface": {
+                  "constant_value": "SCSI"
+                }
+              }
+            ],
+            "tags": {
+              "constant_value": [
+                "foo",
+                "bar"
+              ]
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "mode": "managed",
+          "name": "default",
+          "provider_config_key": "google",
+          "schema_version": 6,
+          "type": "google_compute_instance"
+        },
+        {
+          "address": "google_storage_bucket.example",
+          "expressions": {
+            "labels": {
+              "constant_value": {
+                "Stage": "Prod"
+              }
+            },
+            "location": {
+              "constant_value": "US"
+            },
+            "name": {
+              "constant_value": "example"
+            }
+          },
+          "mode": "managed",
+          "name": "example",
+          "provider_config_key": "google",
+          "schema_version": 0,
+          "type": "google_storage_bucket"
         }
       ]
     }
@@ -233,6 +310,97 @@ mock_config := {
             "tags_all": {
               "Stage": "Prod"
             }
+          }
+        },
+        {
+          "address": "google_compute_instance.default",
+          "mode": "managed",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 6,
+          "type": "google_compute_instance",
+          "values": {
+            "advanced_machine_features": [],
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "disk_encryption_key_raw": null,
+                "initialize_params": [
+                  {
+                    "image": "debian-cloud/debian-9"
+                  }
+                ],
+                "mode": "READ_WRITE"
+              }
+            ],
+            "can_ip_forward": false,
+            "deletion_protection": false,
+            "description": null,
+            "desired_status": null,
+            "enable_display": null,
+            "hostname": null,
+            "labels": null,
+            "machine_type": "e2-medium",
+            "metadata": null,
+            "metadata_startup_script": null,
+            "name": "test",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "public_ptr_domain_name": null
+                  }
+                ],
+                "alias_ip_range": [],
+                "ipv6_access_config": [],
+                "network": "default",
+                "nic_type": null,
+                "queue_count": null
+              }
+            ],
+            "resource_policies": null,
+            "scratch_disk": [
+              {
+                "interface": "SCSI"
+              }
+            ],
+            "service_account": [],
+            "shielded_instance_config": [],
+            "tags": [
+              "bar",
+              "foo"
+            ],
+            "timeouts": null,
+            "zone": "us-central1-a"
+          }
+        },
+        {
+          "address": "google_storage_bucket.example",
+          "mode": "managed",
+          "name": "example",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "type": "google_storage_bucket",
+          "values": {
+            "cors": [],
+            "default_event_based_hold": null,
+            "encryption": [],
+            "force_destroy": false,
+            "labels": {
+              "Stage": "Prod"
+            },
+            "lifecycle_rule": [],
+            "location": "US",
+            "logging": [],
+            "name": "example",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "timeouts": null,
+            "versioning": [],
+            "website": []
           }
         }
       ]
@@ -438,6 +606,182 @@ mock_config := {
       "name": "example",
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "type": "aws_s3_bucket"
+    },
+    {
+      "address": "google_compute_instance.default",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "after": {
+          "advanced_machine_features": [],
+          "allow_stopping_for_update": null,
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "disk_encryption_key_raw": null,
+              "initialize_params": [
+                {
+                  "image": "debian-cloud/debian-9"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "can_ip_forward": false,
+          "deletion_protection": false,
+          "description": null,
+          "desired_status": null,
+          "enable_display": null,
+          "hostname": null,
+          "labels": null,
+          "machine_type": "e2-medium",
+          "metadata": null,
+          "metadata_startup_script": null,
+          "name": "test",
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "public_ptr_domain_name": null
+                }
+              ],
+              "alias_ip_range": [],
+              "ipv6_access_config": [],
+              "network": "default",
+              "nic_type": null,
+              "queue_count": null
+            }
+          ],
+          "resource_policies": null,
+          "scratch_disk": [
+            {
+              "interface": "SCSI"
+            }
+          ],
+          "service_account": [],
+          "shielded_instance_config": [],
+          "tags": [
+            "bar",
+            "foo"
+          ],
+          "timeouts": null,
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "advanced_machine_features": [],
+          "attached_disk": [],
+          "boot_disk": [
+            {
+              "device_name": true,
+              "disk_encryption_key_sha256": true,
+              "initialize_params": [
+                {
+                  "labels": true,
+                  "size": true,
+                  "type": true
+                }
+              ],
+              "kms_key_self_link": true,
+              "source": true
+            }
+          ],
+          "confidential_instance_config": true,
+          "cpu_platform": true,
+          "current_status": true,
+          "guest_accelerator": true,
+          "id": true,
+          "instance_id": true,
+          "label_fingerprint": true,
+          "metadata_fingerprint": true,
+          "min_cpu_platform": true,
+          "network_interface": [
+            {
+              "access_config": [
+                {
+                  "nat_ip": true,
+                  "network_tier": true
+                }
+              ],
+              "alias_ip_range": [],
+              "ipv6_access_config": [],
+              "ipv6_access_type": true,
+              "name": true,
+              "network_ip": true,
+              "stack_type": true,
+              "subnetwork": true,
+              "subnetwork_project": true
+            }
+          ],
+          "project": true,
+          "reservation_affinity": true,
+          "scheduling": true,
+          "scratch_disk": [
+            {}
+          ],
+          "self_link": true,
+          "service_account": [],
+          "shielded_instance_config": [],
+          "tags": [
+            false,
+            false
+          ],
+          "tags_fingerprint": true
+        },
+        "before": null
+      },
+      "mode": "managed",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "type": "google_compute_instance"
+    },
+    {
+      "address": "google_storage_bucket.example",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "after": {
+          "cors": [],
+          "default_event_based_hold": null,
+          "encryption": [],
+          "force_destroy": false,
+          "labels": {
+            "Stage": "Prod"
+          },
+          "lifecycle_rule": [],
+          "location": "US",
+          "logging": [],
+          "name": "example",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "timeouts": null,
+          "versioning": [],
+          "website": []
+        },
+        "after_unknown": {
+          "cors": [],
+          "encryption": [],
+          "id": true,
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "retention_policy": [],
+          "self_link": true,
+          "uniform_bucket_level_access": true,
+          "url": true,
+          "versioning": [],
+          "website": []
+        },
+        "before": null
+      },
+      "mode": "managed",
+      "name": "example",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "type": "google_storage_bucket"
     }
   ],
   "terraform_version": "0.13.7"


### PR DESCRIPTION
These are necessary for the google terraform provider, in order to be consistent
with Fugue.