### PR TITLE
Improve support for `count` attribute in HCL

### DIFF
--- a/pkg/loader/tf_test/count-ref.json
+++ b/pkg/loader/tf_test/count-ref.json
@@ -1,0 +1,31 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.not_working_1": {
+        "_filepath": "tf_test/count-ref/main.tf",
+        "_provider": "aws",
+        "_tags": {},
+        "_type": "aws_s3_bucket",
+        "acl": "private",
+        "bucket": "not-working-1-random-string",
+        "count": 1,
+        "id": "aws_s3_bucket.not_working_1"
+      },
+      "aws_s3_bucket_public_access_block.not_working_1_block": {
+        "_filepath": "tf_test/count-ref/main.tf",
+        "_provider": "aws",
+        "_tags": {},
+        "_type": "aws_s3_bucket_public_access_block",
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "aws_s3_bucket.not_working_1",
+        "count": 1,
+        "id": "aws_s3_bucket_public_access_block.not_working_1_block",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      }
+    }
+  },
+  "filepath": "tf_test/count-ref"
+}

--- a/pkg/loader/tf_test/count-ref/main.tf
+++ b/pkg/loader/tf_test/count-ref/main.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "not_working_1" {
+  count  = var.aws_region == "eu-west-1" ? 1 : 0
+  bucket = "not-working-1-random-string"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "not_working_1_block" {
+  count                   = var.aws_region == "eu-west-1" ? 1 : 0
+  bucket                  = aws_s3_bucket.not_working_1[count.index].id
+  block_public_acls       = aws_s3_bucket.not_working_1[count.index].acl == "private" ? true : false
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/pkg/regulatf/expr.go
+++ b/pkg/regulatf/expr.go
@@ -1,0 +1,41 @@
+// Utilities for working with expressions.
+package regulatf
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ExprAttributes tries to gather all attributes that are being used in a given
+// expression.  For example, for:
+//
+//     aws_s3_bucket.bucket[count.index].acl
+//
+// It would return [acl].
+func ExprAttributes(expr hcl.Expression) []LocalName {
+	names := []LocalName{}
+	if syn, ok := expr.(hclsyntax.Expression); ok {
+		hclsyntax.VisitAll(syn, func(node hclsyntax.Node) hcl.Diagnostics {
+			switch e := node.(type) {
+			case *hclsyntax.RelativeTraversalExpr:
+				if name, err := TraversalToLocalName(e.Traversal); err == nil {
+					names = append(names, name)
+				}
+			case *hclsyntax.IndexExpr:
+				if key := ExprToLiteralString(e.Key); key != nil {
+					name := LocalName{*key}
+					names = append(names, name)
+				}
+			}
+			return nil
+		})
+	}
+	return names
+}
+
+func ExprToLiteralString(expr hcl.Expression) *string {
+	if e, ok := expr.(*hclsyntax.LiteralValueExpr); ok {
+		return ValueToString(e.Val)
+	}
+	return nil
+}

--- a/pkg/regulatf/names_test.go
+++ b/pkg/regulatf/names_test.go
@@ -44,3 +44,38 @@ func TestAsModuleInput(t *testing.T) {
 		FullName{EmptyModuleName, LocalName{"var", "myvar"}}.AsModuleInput(),
 	)
 }
+
+func TestAsResourceName(t *testing.T) {
+	type Test struct {
+		input string
+		full  *FullName
+		index int
+		local LocalName
+	}
+
+	tests := []Test{
+		{
+			input: "module.foo.module.bar.aws_s3_bucket.bucket[3].bucket_prefix",
+			full:  &FullName{ModuleName{"foo", "bar"}, LocalName{"aws_s3_bucket", "bucket"}},
+			index: 3,
+			local: LocalName{"bucket_prefix"},
+		},
+		{
+			input: "aws_s3_bucket.bucket.bucket_prefix",
+			full:  &FullName{ModuleName{}, LocalName{"aws_s3_bucket", "bucket"}},
+			index: -1,
+			local: LocalName{"bucket_prefix"},
+		},
+	}
+
+	for _, test := range tests {
+		name, err := StringToFullName(test.input)
+		if err != nil {
+			t.Fatalf("%s", err)
+		}
+		full, index, local := name.AsResourceName()
+		assert.Equal(t, test.full, full)
+		assert.Equal(t, test.index, index)
+		assert.Equal(t, test.local, local)
+	}
+}

--- a/pkg/regulatf/regulatf.go
+++ b/pkg/regulatf/regulatf.go
@@ -2,8 +2,6 @@
 package regulatf
 
 import (
-	"strings"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"

--- a/pkg/regulatf/value.go
+++ b/pkg/regulatf/value.go
@@ -22,6 +22,15 @@ func ValueToInt(val cty.Value) *int {
 	return nil
 }
 
+func ValueToString(val cty.Value) *string {
+	if !val.IsKnown() || val.IsNull() || val.Type() != cty.String {
+		return nil
+	}
+
+	str := val.AsString()
+	return &str
+}
+
 func ValueToInterface(val cty.Value) interface{} {
 	if !val.IsKnown() || val.IsNull() {
 		return nil


### PR DESCRIPTION
This significantly improves support for the way we handle `count` in HCL. ere
Thare several parts to this PR which work together:

1.  For resources that have a `count`, we structure them as a singleton array
    in the `ValTree`.  This way, it matches up with what the vanilla HCL
    evaluator expects.  So for:

        resource "aws_s3_bucket" "mybucket" {
          count = 3  # Actual number does not matter if it's not 0
          bucket_prefix = "foo"
        }

    We get:

        "aws_s3_bucket": {
          "mybucket": [
            {
              "count": 3,
              "bucket_prefix": "foo"
            }
          ]
        }

    This way, references like `aws_s3_bucket.mybucket[0].bucket_prefix` work as
    expected.

2.  More often than not, we do not refer to these properties as:

        aws_s3_bucket.mybucket[0].bucket_prefix

    Something like this is much more common:

        aws_s3_bucket.mybucket[count.index].bucket_prefix

    However, this leads to several problems!

    To back up a bit, there are two kinds of properties you can refer to:

     -  `aws_s3_bucket.mybucket[count.index].bucket_prefix` is a reference
        to an existing property.  Without the `count.index`, we can directly
        point this to the right, corresponding expression.
     -  `aws_s3_bucket.mybucket[count.index].bucket` is a reference to something
        that *does not* exist.  Before, we would note this absence and replace
        it by the resource name (`aws_s3_bucket.mybucket`).

    However, due to the `[count.index].bucket_prefix`, we now end up with a much
    different expression, where we need provide the actual object to the
    vanilla HCL evaluator, so it can do the indexing for us (rather than us
    looking directly at the source property).

3.  Constructing this object is a bit tricky, since we do not know what absent
    fields will be used (`id`?  `bucket`?  `arn`?).  This is where a new
    `ExprAttributes` function comes in -- this traverses a whole expression and
    makes a guess at which attributes are used.  False positives are possible,
    but only result in a little extra work, not a lack of correctness.

    To then construct this object, we use two strategies.

     -  For *present* attributes, we just copy everything over from the
        relevant HCL expressions.  This means that expressions which use these
        will have a lot more dependencies than before.  There is some new
        code, including `ResourceExpressions`, to track these dependencies.

     -  For *absent* attributes, we copy in the resource name as before.

    We can then pass the object to the vanilla HCL evaluator and pretend it's
    a normal object.

4.  There are some misc. parts:

     -  Added an `IsBuiltin` function to names so we can properly handle the
       `count.index` expression.
     -  Split `VisitResource` into `EnterResource` / `ExitResource` to handle
        tracking of `ResourceExpressions`.
     -  ...