### PR TITLE
Docs updates for v2.6.0

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -17,6 +17,9 @@ Or a directory that includes your other Rego rules and libraries:
 
 ## Waiving rule results
 
+!!! note
+    For information about waiving rules for [Fugue repository environments](https://docs.fugue.co/waivers.html), see [Regula and Fugue](fugue.md).
+
 Regula enables you to waive a rule for resources or rules that match certain attributes.  When a rule is waived for a resource, the result (`PASS` or `FAIL`) becomes `WAIVED` and is effectively ignored in compliance calculations.
 
 The following rule result attributes, which are also in the [Regula report output](report.md), are supported for waiver objects:

--- a/docs/src/development/writing-rules.md
+++ b/docs/src/development/writing-rules.md
@@ -93,6 +93,7 @@ The `fugue` API consists of these functions for advanced rules:
 
 -   `fugue.resources(resource_type)` returns an object with all resources of
     the requested type.
+    `fugue.input_resource_types` is a set with all resource types in the input document.
 -   `fugue.allow_resource(resource)` marks a resource as valid.
 -   `fugue.deny_resource(resource)` marks a resource as invalid.
 -   `fugue.deny_resource_with_message(resource, msg)` marks a resource as invalid and displays a custom `rule_message` in the report.
@@ -188,23 +189,26 @@ Here's an example rule result to show how this metadata looks in the report:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
-      "filepath": "../regula-ci-example/infra_tf/",
+      "families": [
+        "CORPORATE-POLICY"
+      ],
+      "filepath": "../regula-ci-example/infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
       "rule_name": "long_description",
       "rule_raw_result": false,
-      "rule_remediation_doc": "https://example.com",
       "rule_result": "FAIL",
       "rule_severity": "Low",
       "rule_summary": "IAM policies must have a description of at least 25 characters",
       "source_location": [
         {
-          "path": "../regula-ci-example/infra_tf/",
+          "path": "../regula-ci-example/infra_tf/main.tf",
           "line": 6,
           "column": 1
         }

--- a/docs/src/examples/debug-tutorial.md
+++ b/docs/src/examples/debug-tutorial.md
@@ -153,6 +153,7 @@ Here's the output:
   "google_storage_bucket.bad": {
     "_filepath": "bucket.tf",
     "_provider": "google",
+    "_tags": {},
     "_type": "google_storage_bucket",
     "id": "google_storage_bucket.bad",
     "location": "US",
@@ -167,6 +168,7 @@ Here's the output:
   "google_storage_bucket.good": {
     "_filepath": "bucket.tf",
     "_provider": "google",
+    "_tags": {},
     "_type": "google_storage_bucket",
     "id": "google_storage_bucket.good",
     "lifecycle_rule": [

--- a/docs/src/examples/waive-and-disable.md
+++ b/docs/src/examples/waive-and-disable.md
@@ -34,7 +34,7 @@ Make sure you're in the `regula-ci-example` directory and run this command:
 regula run -f json --include example_custom_rule infra_tf
 ```
 
-We see this output:
+We see this output (edited for length):
 
 ```json
 {
@@ -43,11 +43,15 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -68,11 +72,15 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -92,13 +100,20 @@ We see this output:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -119,13 +134,20 @@ We see this output:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -151,7 +173,7 @@ We see this output:
     ],
     "rule_results": {
       "FAIL": 2,
-      "PASS": 4,
+      "PASS": 6,
       "WAIVED": 0
     },
     "severities": {
@@ -203,7 +225,7 @@ Here's the full command:
 regula run -f json --include example_custom_rule --include config.rego infra_tf
 ```
 
-We see this output:
+We see this output (which we've edited for length):
 
 ```json
 {
@@ -212,11 +234,15 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -237,11 +263,15 @@ We see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -261,13 +291,20 @@ We see this output:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -288,13 +325,20 @@ We see this output:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -320,7 +364,7 @@ We see this output:
     ],
     "rule_results": {
       "FAIL": 1,
-      "PASS": 4,
+      "PASS": 6,
       "WAIVED": 1
     },
     "severities": {
@@ -335,7 +379,7 @@ We see this output:
 }
 ```
 
-This time, there are 1 FAIL, 4 PASS, and 1 WAIVED rule results! You can see in the output that the `rule_result` value is `WAIVED` for the rule `long_description` and resource `aws_iam_policy.basically_allow_all`.
+This time, there are 1 FAIL, 6 PASS, and 1 WAIVED rule results! You can see in the output that the `rule_result` value is `WAIVED` for the rule `long_description` and resource `aws_iam_policy.basically_allow_all`.
 
 Hooray! You've just configured Regula to waive a rule result for a resource. Your next mission: disabling a rule!
 
@@ -360,7 +404,7 @@ Run the same command we ran a moment ago:
 regula run -f json --include example_custom_rule --include config.rego infra_tf
 ```
 
-We'll see this output:
+We'll see this output (again, edited for length):
 
 ```json
 {
@@ -369,11 +413,15 @@ We'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -394,11 +442,15 @@ We'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -423,7 +475,7 @@ We'll see this output:
     ],
     "rule_results": {
       "FAIL": 0,
-      "PASS": 3,
+      "PASS": 5,
       "WAIVED": 1
     },
     "severities": {
@@ -438,7 +490,7 @@ We'll see this output:
 }
 ```
 
-Now there are just 4 rule results: 3 PASS and 1 WAIVED. As you can see, the rule `tf_aws_iam_admin_policy` was totally ignored.
+Now there are just 6 rule results: 5 PASS and 1 WAIVED. As you can see, the rule `tf_aws_iam_admin_policy` was totally ignored.
 
 Nice job! You just configured Regula to disable a rule. 
 

--- a/docs/src/examples/writing-a-rule.md
+++ b/docs/src/examples/writing-a-rule.md
@@ -115,7 +115,9 @@ You'll see this output:
 ```json
 {
   "aws_iam_policy.basically_allow_all": {
+    "_filepath": "infra_tf/main.tf",
     "_provider": "aws",
+    "_tags": {},
     "_type": "aws_iam_policy",
     "description": "Some policy",
     "id": "aws_iam_policy.basically_allow_all",
@@ -124,7 +126,9 @@ You'll see this output:
     "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"*\",\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
   },
   "aws_iam_policy.basically_deny_all": {
+    "_filepath": "infra_tf/main.tf",
     "_provider": "aws",
+    "_tags": {},
     "_type": "aws_iam_policy",
     "description": "Some policy with a long description that denies anything",
     "id": "aws_iam_policy.basically_deny_all",
@@ -138,6 +142,12 @@ You'll see this output:
 Here you can see that there are two resources defined, both of the type `aws_iam_policy`. The attribute `description` is what we're looking for, and it's located at the level directly beneath the resource ID. That means it's a top-level attribute -- it's not nested under any other attribute.
 
 If you'd like to learn more about using the REPL for developing rules, take a detour to [Test Inputs](../development/test-inputs.md).
+
+Now you can exit the REPL:
+
+```
+exit
+```
 
 ### Specify the condition
 
@@ -232,11 +242,15 @@ You'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",
@@ -257,11 +271,15 @@ You'll see this output:
       "controls": [
         "CORPORATE-POLICY_1.1"
       ],
+      "families": [
+        "CORPORATE-POLICY"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
       "rule_id": "CUSTOM_0001",
       "rule_message": "",

--- a/docs/src/fugue.md
+++ b/docs/src/fugue.md
@@ -6,26 +6,25 @@ Regula can be used in conjunction with [Fugue](https://www.fugue.co) to ensure i
 
 To set up a repository environment, see the [Fugue docs](https://docs.fugue.co/setup-repository.html).
 
-## Syncing rules and families from Fugue
+## Syncing rules, families, and waivers from Fugue
 
-Using [`regula run`](usage.md#run) with the `--sync` flag instructs Regula to evaluate your IaC templates using the rules and families enabled for the associated Fugue repository environment. The rules that are applied to your IaC are determined by the compliance families you selected for the environment.
+!!! note
+    Syncing applies any relevant [Fugue waivers](https://docs.fugue.co/waivers.html) enabled for your repository environment. This is a one-way sync; [local waivers](configuration.md#waiving-rule-results) are not applied or synced to Fugue.
+
+Using [`regula run`](usage.md#run) with the `--sync` flag instructs Regula to evaluate your IaC templates using the rules, families, and [waivers](https://docs.fugue.co/waivers.html) enabled for the associated Fugue repository environment. The rules that are applied to your IaC are determined by the compliance families you selected for the environment.
 
 The Fugue repository environment is specified in the `.regula.yaml` configuration file, which is generated when you execute [`regula init --environment-id <environment_id>`](usage.md#init) (see the [Fugue docs](https://docs.fugue.co/setup-repository.html#step-5-kicking-off-a-scan)).
 
-To run Regula locally with synced rules:
+To run Regula locally with synced rules/families/waivers:
 
 ```
 regula run --sync
 ```
 
-To run Regula locally with synced rules and _also_ send Regula's results to Fugue:
+To run Regula locally with synced rules/families/waivers and _also_ send Regula's results to Fugue:
 
 ```
 regula run --sync --upload
 ```
 
-Be aware that `--sync` overrides other flags that would select rules. For instance, if you use `--sync`, you cannot also use the `--only` flag to select only a single rule, and you cannot use `--include` or `--exclude` to include/exclude other directories of rules. `--sync` ensures that Regula applies the rules configured in your Fugue repository environment.
-
-## Syncing waivers from Fugue
-
-Waivers are not currently synced from Fugue. This support will be added in a future release.
+Be aware that `--sync` overrides other flags that would select rules. For instance, if you use `--sync`, you cannot also use the `--only` flag to select only a single rule, and you cannot use `--include` or `--exclude` to include/exclude other directories of rules or local waivers. `--sync` ensures that Regula applies the rules/families/waivers configured in your Fugue repository environment.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -147,13 +147,20 @@ You'll see output like this:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -174,13 +181,20 @@ You'll see output like this:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -199,12 +213,82 @@ You'll see output like this:
       ]
     },
     {
-      "controls": [],
+      "controls": [
+        "CIS-AWS_v1.2.0_1.16",
+        "CIS-AWS_v1.3.0_1.15",
+        "CIS-AWS_v1.4.0_1.15"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
+      ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
+      "rule_description": "IAM policies should not be attached to users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may reduce opportunity for a principal to inadvertently receive or retain excessive privileges.",
+      "rule_id": "FG_R00007",
+      "rule_message": "",
+      "rule_name": "tf_aws_iam_policy",
+      "rule_raw_result": true,
+      "rule_remediation_doc": "https://docs.fugue.co/FG_R00007.html",
+      "rule_result": "PASS",
+      "rule_severity": "Low",
+      "rule_summary": "IAM policies should not be attached to users",
+      "source_location": [
+        {
+          "path": "infra_tf/main.tf",
+          "line": 6,
+          "column": 1
+        }
+      ]
+    },
+    {
+      "controls": [
+        "CIS-AWS_v1.2.0_1.16",
+        "CIS-AWS_v1.3.0_1.15",
+        "CIS-AWS_v1.4.0_1.15"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
+      ],
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
+      "provider": "aws",
+      "resource_id": "aws_iam_policy.basically_deny_all",
+      "resource_type": "aws_iam_policy",
+      "resource_tags": {},
+      "rule_description": "IAM policies should not be attached to users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may reduce opportunity for a principal to inadvertently receive or retain excessive privileges.",
+      "rule_id": "FG_R00007",
+      "rule_message": "",
+      "rule_name": "tf_aws_iam_policy",
+      "rule_raw_result": true,
+      "rule_remediation_doc": "https://docs.fugue.co/FG_R00007.html",
+      "rule_result": "PASS",
+      "rule_severity": "Low",
+      "rule_summary": "IAM policies should not be attached to users",
+      "source_location": [
+        {
+          "path": "infra_tf/main.tf",
+          "line": 25,
+          "column": 1
+        }
+      ]
+    },
+    {
+      "controls": [],
+      "families": [],
+      "filepath": "infra_tf/main.tf",
+      "input_type": "tf",
+      "provider": "aws",
+      "resource_id": "aws_iam_policy.basically_allow_all",
+      "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not allow broad list actions on S3 buckets. Should a malicious actor gain access to a role with a policy that includes broad list actions such as ListAllMyBuckets, the malicious actor would be able to enumerate all buckets and potentially extract sensitive data.",
       "rule_id": "FG_R00218",
       "rule_message": "",
@@ -224,11 +308,13 @@ You'll see output like this:
     },
     {
       "controls": [],
+      "families": [],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not allow broad list actions on S3 buckets. Should a malicious actor gain access to a role with a policy that includes broad list actions such as ListAllMyBuckets, the malicious actor would be able to enumerate all buckets and potentially extract sensitive data.",
       "rule_id": "FG_R00218",
       "rule_message": "",
@@ -253,7 +339,7 @@ You'll see output like this:
     ],
     "rule_results": {
       "FAIL": 1,
-      "PASS": 3,
+      "PASS": 5,
       "WAIVED": 0
     },
     "severities": {
@@ -270,7 +356,7 @@ You'll see output like this:
 
 ### What does it mean?
 
-Regula just showed us that our [sample Terraform](https://github.com/fugue/regula-ci-example/blob/master/infra_tf/main.tf) is noncompliant and a security vulnerability. In this example, there are 4 rule results: 3 PASS and 1 FAIL.
+Regula just showed us that our [sample Terraform](https://github.com/fugue/regula-ci-example/blob/master/infra_tf/main.tf) is noncompliant and a security vulnerability. In this example, there are 6 rule results: 5 PASS and 1 FAIL.
 
 The AWS IAM policy resource `aws_iam_policy.basically_allow_all` failed the Regula rule ["IAM policies should not have full `"*:*"` administrative privileges."](https://github.com/fugue/regula/blob/master/rego/rules/tf/aws/iam/admin_policy.rego) The report includes lots of other info, such as the filepath, line, and column the resource was found in; the rule severity; a full description of the rule; and more:
 
@@ -278,13 +364,20 @@ The AWS IAM policy resource `aws_iam_policy.basically_allow_all` failed the Regu
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_allow_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -310,13 +403,20 @@ In contrast, the policy `aws_iam_policy.basically_deny_all` passed the rule:
     {
       "controls": [
         "CIS-AWS_v1.2.0_1.22",
-        "CIS-AWS_v1.3.0_1.16"
+        "CIS-AWS_v1.3.0_1.16",
+        "CIS-AWS_v1.4.0_1.16"
+      ],
+      "families": [
+        "CIS-AWS_v1.2.0",
+        "CIS-AWS_v1.3.0",
+        "CIS-AWS_v1.4.0"
       ],
       "filepath": "infra_tf/main.tf",
       "input_type": "tf",
       "provider": "aws",
       "resource_id": "aws_iam_policy.basically_deny_all",
       "resource_type": "aws_iam_policy",
+      "resource_tags": {},
       "rule_description": "IAM policies should not have full \"*:*\" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.",
       "rule_id": "FG_R00092",
       "rule_message": "",
@@ -345,7 +445,7 @@ The summary lists the filenames evaluated, the number of FAIL/PASS/[WAIVED](conf
     ],
     "rule_results": {
       "FAIL": 1,
-      "PASS": 3,
+      "PASS": 5,
       "WAIVED": 0
     },
     "severities": {

--- a/docs/src/report.md
+++ b/docs/src/report.md
@@ -19,6 +19,9 @@ Here's a snippet of test results from a Regula JSON report:
       "provider": "azurerm",
       "resource_id": "azurerm_network_security_group.devnsg",
       "resource_type": "azurerm_network_security_group",
+      "resource_tags": {
+        "environment": "dev"
+      },
       "rule_description": "Virtual Network security group flow log retention period should be set to 90 days or greater. Flow logs enable capturing information about IP traffic flowing in and out of network security groups. Logs can be used to check for anomalies and give insight into suspected breaches.",
       "rule_id": "FG_R00286",
       "rule_message": "",
@@ -50,6 +53,9 @@ Here's a snippet of test results from a Regula JSON report:
       "provider": "azurerm",
       "resource_id": "azurerm_network_security_group.devnsg",
       "resource_type": "azurerm_network_security_group",
+      "resource_tags": {
+        "environment": "dev"
+      },
       "rule_description": "Virtual Network security groups should not permit ingress from '0.0.0.0/0' to TCP/UDP port 22 (SSH). The potential security problem with using SSH over the internet is that attackers can use various brute force techniques to gain access to Azure Virtual Machines. Once the attackers gain access, they can use a virtual machine as a launch point for compromising other machines on the Azure Virtual Network or even attack networked devices outside of Azure.",
       "rule_id": "FG_R00191",
       "rule_message": "",
@@ -81,6 +87,9 @@ Here's a snippet of test results from a Regula JSON report:
       "provider": "azurerm",
       "resource_id": "azurerm_storage_account.main",
       "resource_type": "azurerm_storage_account",
+      "resource_tags": {
+        "environment": "dev"
+      },
       "rule_description": "Storage Accounts 'Secure transfer required' should be enabled. The secure transfer option enhances the security of a storage account by only allowing requests to the storage account by a secure connection. This control does not apply for custom domain names since Azure storage does not support HTTPS for custom domain names.",
       "rule_id": "FG_R00152",
       "rule_message": "",
@@ -148,6 +157,7 @@ Each rule result in the JSON report lists the following attributes:
 - `provider`: `aws`, `azurerm`, `google`, `kubernetes`, `arm`
 - `resource_id`: ID of the evaluated resource
 - `resource_type`: Type of the evaluated resource
+- `resource_tags`: Normalized resource tags/labels
 - `rule_description`: A detailed description of the rule
 - `rule_id`: ID of the rule; built-in rules start with `FG_R`
 - `rule_message`: Optional error message associated with the rule; see how to create custom error messages in [simple](development/writing-rules.md#custom-error-messages-and-attributes-simple-rules) and [advanced](development/writing-rules.md#custom-error-messages-advanced-rules) custom rules
@@ -158,6 +168,7 @@ Each rule result in the JSON report lists the following attributes:
 - `rule_severity`: `Critical`, `High`, `Medium`, `Low`, `Informational`, or `Unknown`
 - `rule_summary`: A short summary of the rule
 - `source_location`: The path, line, and column of the evaluated resource
+- `active_waivers`: A list of [Fugue waiver](https://docs.fugue.co/waivers.html) IDs applied to the relevant [Fugue repository environment](https://docs.fugue.co/setup-repository.html) (not applicable when running Regula without `--sync`)
 
 ## Compliance controls vs. rules
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -153,6 +153,7 @@ Regula operates on ARM templates formatted as JSON.
 - `junit` -- The JUnit XML format
 - `tap` -- The Test Anything Protocol format
 - `compact` -- An alternate, more compact human friendly format
+- `sarif` -- Static Analysis Results Interchange Format
 - `none` -- Do not print any output on stdout
 
 `-t, --input type INPUT-TYPE` values:
@@ -269,11 +270,15 @@ Use the `--f | --format FORMAT` flag to specify the output format:
           "controls": [
             "CORPORATE-POLICY_1.1"
           ],
+          "families": [
+            "CORPORATE-POLICY"
+          ],
           "filepath": "infra_cfn/invalid_long_description.yaml",
           "input_type": "cfn",
           "provider": "aws",
           "resource_id": "InvalidManagedPolicy01",
           "resource_type": "AWS::IAM::ManagedPolicy",
+          "resource_tags": {},
           "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
           "rule_id": "CUSTOM_0001",
           "rule_message": "",
@@ -294,11 +299,15 @@ Use the `--f | --format FORMAT` flag to specify the output format:
           "controls": [
             "CORPORATE-POLICY_1.1"
           ],
+          "families": [
+            "CORPORATE-POLICY"
+          ],
           "filepath": "infra_cfn/invalid_long_description.yaml",
           "input_type": "cfn",
           "provider": "aws",
           "resource_id": "ValidManagedPolicy01",
           "resource_type": "AWS::IAM::ManagedPolicy",
+          "resource_tags": {},
           "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
           "rule_id": "CUSTOM_0001",
           "rule_message": "",
@@ -340,14 +349,14 @@ Use the `--f | --format FORMAT` flag to specify the output format:
 === "table"
 
     ```
-    +------------------------+-------------------------+----------------------------------------------+----------+-------------+----------------------+----------------------------------------------------------------+--------+
-    |        Resource        |          Type           |                   Filepath                   | Severity |   Rule ID   |      Rule Name       |                            Message                             | Result |
-    +------------------------+-------------------------+----------------------------------------------+----------+-------------+----------------------+----------------------------------------------------------------+--------+
-    | InvalidManagedPolicy01 | AWS::IAM::ManagedPolicy | infra_cfn/invalid_long_description.yaml:14:3 | Low      | CUSTOM_0001 | long_description_cfn | IAM policies must have a description of at least 25 characters | FAIL   |
-    | ValidManagedPolicy01   | AWS::IAM::ManagedPolicy | infra_cfn/invalid_long_description.yaml:3:3  | Low      | CUSTOM_0001 | long_description_cfn | IAM policies must have a description of at least 25 characters | PASS   |
-    +------------------------+-------------------------+----------------------------------------------+----------+-------------+----------------------+----------------------------------------------------------------+--------+
-    |                        |                         |                                              |          |             |                      |                                                        Overall | FAIL   |
-    +------------------------+-------------------------+----------------------------------------------+----------+-------------+----------------------+----------------------------------------------------------------+--------+
+    +--------+------------------------+----------+-------------------------+----------------------------------------------+-------------+----------------------+----------------------------------------------------------------+
+    | Result |        Resource        | Severity |          Type           |                   Filepath                   |   Rule ID   |      Rule Name       |                            Message                             |
+    +--------+------------------------+----------+-------------------------+----------------------------------------------+-------------+----------------------+----------------------------------------------------------------+
+    | FAIL   | InvalidManagedPolicy01 | Low      | AWS::IAM::ManagedPolicy | infra_cfn/invalid_long_description.yaml:14:3 | CUSTOM_0001 | long_description_cfn | IAM policies must have a description of at least 25 characters |
+    | PASS   | ValidManagedPolicy01   | Low      | AWS::IAM::ManagedPolicy | infra_cfn/invalid_long_description.yaml:3:3  | CUSTOM_0001 | long_description_cfn | IAM policies must have a description of at least 25 characters |
+    +--------+------------------------+----------+-------------------------+----------------------------------------------+-------------+----------------------+----------------------------------------------------------------+
+    | FAIL   | Overall                |          |                         |                                              |             |                      |                                                                |
+    +--------+------------------------+----------+-------------------------+----------------------------------------------+-------------+----------------------+----------------------------------------------------------------+
     ```
 
 === "junit"
@@ -376,6 +385,114 @@ Use the `--f | --format FORMAT` flag to specify the output format:
     CUSTOM_0001: IAM policies must have a description of at least 25 characters [Low]
       [1]: InvalidManagedPolicy01 in infra_cfn/invalid_long_description.yaml:14:3
     Found one problem.
+    ```
+
+=== "sarif"
+
+    ```json
+    {
+      "version": "2.1.0",
+      "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+      "runs": [
+        {
+          "tool": {
+            "driver": {
+              "informationUri": "https://regula.dev",
+              "name": "regula",
+              "rules": [
+                {
+                  "id": "CUSTOM_0001",
+                  "shortDescription": {
+                    "text": "IAM policies must have a description of at least 25 characters"
+                  },
+                  "fullDescription": {
+                    "text": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
+                    "markdown": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters."
+                  }
+                }
+              ],
+              "semanticVersion": ""
+            }
+          },
+          "artifacts": [
+            {
+              "location": {
+                "uri": "infra_cfn/invalid_long_description.yaml"
+              },
+              "length": -1
+            }
+          ],
+          "results": [
+            {
+              "properties": {
+                "controls": [
+                  "CORPORATE-POLICY_1.1"
+                ],
+                "families": [
+                  "CORPORATE-POLICY"
+                ],
+                "inputType": "cfn",
+                "resourceId": "InvalidManagedPolicy01",
+                "resourceType": "AWS::IAM::ManagedPolicy"
+              },
+              "ruleId": "CUSTOM_0001",
+              "ruleIndex": 0,
+              "kind": "fail",
+              "level": "error",
+              "message": {
+                "text": "IAM policies must have a description of at least 25 characters"
+              },
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "infra_cfn/invalid_long_description.yaml"
+                    },
+                    "region": {
+                      "startLine": 14,
+                      "startColumn": 3
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "properties": {
+                "controls": [
+                  "CORPORATE-POLICY_1.1"
+                ],
+                "families": [
+                  "CORPORATE-POLICY"
+                ],
+                "inputType": "cfn",
+                "resourceId": "ValidManagedPolicy01",
+                "resourceType": "AWS::IAM::ManagedPolicy"
+              },
+              "ruleId": "CUSTOM_0001",
+              "ruleIndex": 0,
+              "kind": "pass",
+              "level": "none",
+              "message": {
+                "text": "IAM policies must have a description of at least 25 characters"
+              },
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "infra_cfn/invalid_long_description.yaml"
+                    },
+                    "region": {
+                      "startLine": 3,
+                      "startColumn": 3
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
     ```
 
 You can also set the output format using the `REGULA_FORMAT` environment variable:
@@ -526,7 +643,7 @@ When using Regula with [Fugue](https://www.fugue.co), set the environment ID for
 regula init --environment-id a29aec17-ab48-42dc-ade5-c0ba8b650c4c
 ```
 
-Sync the built-in and custom rules from your [Fugue](https://www.fugue.co) tenant when running Regula locally:
+Sync the built-in and custom rules/families/waivers from your [Fugue](https://www.fugue.co) tenant when running Regula locally:
 
 ```
 regula init --environment-id a29aec17-ab48-42dc-ade5-c0ba8b650c4c --sync


### PR DESCRIPTION
This PR updates the docs for the following:

- New SARIF output format
- Updated table output format
- New `active_waivers` and `resource_tags` fields in JSON output
- Syncing waivers from Fugue to Regula
- Updated output for examples throughout