### PR TITLE
deps: update to use go1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,21 @@
+name: main
+
 on: [pull_request, push]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test
+    name: Test with Go ${{ matrix.go }}
+    strategy:
+      matrix:
+        go: ["1.17", "1.18"]
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        go-version: ${{ matrix.go }}
     - name: Go test
       run: make test
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.18'
       - name: Install tools
         run: make install_tools
       - name: Extract tag name from git ref

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 **Tip: See all of our documentation at [regula.dev](https://regula.dev)!**
 
-- [Introduction](#introduction)
-- [Installation](#installation)
-  - [Homebrew](#homebrew-macos--linux)
-  - [Prebuilt binary (all platforms)](#prebuilt-binary-all-platforms)
-  - [Docker (all platforms)](#docker-all-platforms)
-  - [From source](#from-source)
-- [Usage](#usage)
-- [For more information](#for-more-information)
+- [Regula](#regula)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Homebrew (macOS & Linux)](#homebrew-macos--linux)
+    - [Prebuilt binary (all platforms)](#prebuilt-binary-all-platforms)
+    - [Docker (all platforms)](#docker-all-platforms)
+    - [From source](#from-source)
+  - [Usage](#usage)
+  - [For more information](#for-more-information)
 
 ## Introduction
 
@@ -95,7 +96,7 @@ For usage, see [Running Regula with Docker](https://regula.dev/usage.html#runnin
 
 _macOS, Linux, and [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) only_
 
-1. [Install Go (v1.16+)](https://go.dev/doc/install)
+1. [Install Go (v1.17+)](https://go.dev/doc/install)
 
 2. Build binary and move to `/usr/local/bin/regula`:
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -42,7 +42,7 @@ brew upgrade regula
         move regula.exe C:\regula\bin
         setx PATH "%PATH%;C:\regula\bin"
         ```
-    
+
     === "Windows (PowerShell)"
 
         ```powershell
@@ -67,7 +67,7 @@ brew upgrade regula
             regula
 
     5. macOS will ask you to confirm that you want to open it. Select "Open."
-    
+
     You can now execute regula commands.
 
 ### Docker (all platforms)
@@ -84,7 +84,7 @@ For usage, see [Running Regula with Docker](usage.md#running-regula-with-docker)
 !!! note
     macOS, Linux, and [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) only
 
-1. [Install Go (v1.16+)](https://go.dev/doc/install)
+1. [Install Go (v1.17+)](https://go.dev/doc/install)
 
 2. Build binary and move to `/usr/local/bin/regula`:
 

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/fugue/regula/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/agext/levenshtein v1.2.3
 	github.com/alexeyco/simpletable v1.0.0
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 // indirect
 	github.com/apparentlymart/go-versions v1.0.1
 	github.com/bmatcuk/doublestar v1.3.4
-	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/fatih/color v1.13.0
 	github.com/go-git/go-git/v5 v5.4.2
@@ -29,14 +27,11 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/panicwrap v1.0.0
 	github.com/open-policy-agent/opa v0.37.2
 	github.com/owenrumney/go-sarif/v2 v2.1.1
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.3.0
@@ -46,12 +41,74 @@ require (
 	github.com/tailscale/hujson v0.0.0-20210818175511-7360507a6e88
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-yaml v1.0.2
-	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/mod v0.5.0
 	golang.org/x/net v0.0.0-20211111083644-e5c967477495
-	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.1.5
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/OneOfOne/xxhash v1.2.8 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-openapi/analysis v0.19.10 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/loads v0.19.5 // indirect
+	github.com/go-openapi/spec v0.19.8 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.1 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.12 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/rivo/uniseg v0.1.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
- ci: build/test with go{1.17, 1.18}, release with go1.18
- deps: update go requirement to 1.17+ (as go1.16 is not maintained)

---

action run ref, https://github.com/chenrui333/regula/actions/runs/2009828046