### PR TITLE
Docs: Fix 'Edit on GitHub' link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ markdown_extensions:
   - toc:
       permalink: ⚓︎
 site_url: https://regula.dev
-edit_uri: blob/master/docs/
+edit_uri: blob/master/docs/src/
 extra:
   version: v2.6.1
   social:


### PR DESCRIPTION
This PR fixes the "Edit this page" links on each page of the docs site. These links broke when we moved the docs to `docs/src/`.