### PR TITLE
[CLOUD-233] Rule updates

### DIFF
--- a/rego/rules/k8s/service_account_tokens.rego
+++ b/rego/rules/k8s/service_account_tokens.rego
@@ -30,32 +30,32 @@ input_type := "k8s"
 
 resource_type := "MULTIPLE"
 
-is_valid(template) {
-	template.spec.automountServiceAccountToken == false
+is_valid(spec) {
+	spec.automountServiceAccountToken == false
 }
 
 policy[j] {
 	obj := k8s.resources_with_pod_templates[_]
 	count(obj.pod_template.spec.containers) > 0
-	is_valid(obj.pod_template)
+	is_valid(obj.pod_template.spec)
 	j = fugue.allow_resource(obj.resource)
 }
 
 policy[j] {
 	obj := k8s.resources_with_pod_templates[_]
 	count(obj.pod_template.spec.containers) > 0
-	not is_valid(obj.pod_template)
+	not is_valid(obj.pod_template.spec)
 	j = fugue.deny_resource(obj.resource)
 }
 
 policy[j] {
-	resource := fugue.resources("ServiceAccount")
+	resource := fugue.resources("ServiceAccount")[_]
 	is_valid(resource)
 	j = fugue.allow_resource(resource)
 }
 
 policy[j] {
-	resource := fugue.resources("ServiceAccount")
+	resource := fugue.resources("ServiceAccount")[_]
 	not is_valid(resource)
 	j = fugue.deny_resource(resource)
 }

--- a/rego/rules/tf/aws/cloudtrail/management_events.rego
+++ b/rego/rules/tf/aws/cloudtrail/management_events.rego
@@ -24,8 +24,19 @@ __rego__metadoc__ := {
 
 resource_type := "aws_cloudtrail"
 
+contains_element(arr, elem) = true {
+  arr[_] = elem
+} else = false { true }
+
 default deny = false
 
 deny {
   input.event_selector[_].include_management_events == false
+}
+
+deny {
+  field_selectors = [i | i := input.advanced_event_selector[_].field_selector[_]]
+  count(field_selectors) > 0
+  a = [i | i := contains_element(field_selectors[_].equals, "Management")]
+  not any(a)
 }

--- a/rego/rules/tf/aws/s3/block_public_access.rego
+++ b/rego/rules/tf/aws/s3/block_public_access.rego
@@ -48,6 +48,7 @@ policy[j] {
 
 buckets = fugue.resources("aws_s3_bucket")
 bucket_access_blocks = fugue.resources("aws_s3_bucket_public_access_block")
+account_access_blocks = fugue.resources("aws_s3_account_public_access_block")
 
 # Using the `bucket_access_blocks`, we construct a set of bucket IDs that have
 # the public access blocked.
@@ -60,7 +61,17 @@ blocked_buckets[bucket_name] {
     block.restrict_public_buckets == true
 }
 
+blocked_account {
+    block := account_access_blocks[_]
+    block.block_public_acls == true
+    block.ignore_public_acls == true
+    block.block_public_policy == true
+    block.restrict_public_buckets == true
+}
+
 bucket_is_blocked(bucket) {
+  blocked_account
+} {
   fugue.input_type != "tf_runtime"
   blocked_buckets[bucket.id]
 } {

--- a/rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.json
+++ b/rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.json
@@ -1,3 +1,4 @@
+# some comment
 {
   "format_version": "0.1",
   "terraform_version": "0.13.5",
@@ -449,5 +450,5 @@
         }
       ]
     }
-  }
+  },
 }

--- a/rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.json
+++ b/rego/tests/rules/tf/aws/s3/inputs/bucket_sse_infra.json
@@ -1,4 +1,3 @@
-# some comment
 {
   "format_version": "0.1",
   "terraform_version": "0.13.5",
@@ -450,5 +449,5 @@
         }
       ]
     }
-  },
+  }
 }


### PR DESCRIPTION
This PR propagates several recent rule updates to regula:

* Fixed nacl rule handling in `nacl_library.rego` [CLOUD-87]
* Fixed FG_R00484 for ServiceAccount [CLOUD-56]
* Support advanced_event_selector in FG_R00237 [CLOUD-69]
* Update FG_R00299 to allow account level block [CLOUD-68]
* Update FG_R00099 with new s3 encryption config resource [CLOUD-233]
