### PR TITLE
[CLOUD-242] Update TF AWS rules for provider v4

### DIFF
--- a/rego/lib/aws/s3/s3_library.rego
+++ b/rego/lib/aws/s3/s3_library.rego
@@ -32,6 +32,18 @@ bucket_policies_for_bucket(bucket) = ret {
   )
 }
 
+bucket_acls_by_bucket := ret {
+  fugue.input_resource_types["aws_s3_bucket_acl"]
+  acls := fugue.resources("aws_s3_bucket_acl")
+  ret := {acl.bucket: acl | acl := acls[_]}
+}
+
+bucket_logging_by_bucket := ret {
+  fugue.input_resource_types["aws_s3_bucket_logging"]
+  confs := fugue.resources("aws_s3_bucket_logging")
+  ret := {conf.bucket: conf | conf := confs[_]}
+}
+
 matches_bucket_or_id(val, bucket) {
   not is_null(val)
   val == bucket.bucket

--- a/rego/lib/aws/security_groups/library.rego
+++ b/rego/lib/aws/security_groups/library.rego
@@ -59,8 +59,15 @@ rule_all_ports(rule) {
 }
 
 rule_all_ports(rule) {
-	rule.from_port == 0
-	rule.to_port == 0
+	rule.protocol == -1
+}
+
+rule_all_ports(rule) {
+	rule.protocol == "-1"
+}
+
+rule_all_ports(rule) {
+	lower(rule.protocol) == "all"
 }
 
 # Does an ingress block allow access from the zero CIDR to a given port?

--- a/rego/rules/tf/aws/cloudtrail/s3_access_logging.rego
+++ b/rego/rules/tf/aws/cloudtrail/s3_access_logging.rego
@@ -45,7 +45,15 @@ buckets_by_name = {bucket_name: bucket |
 }
 
 target_has_access_logging(ct) {
-  count(buckets_by_name[ct.s3_bucket_name].logging) > 0
+  bucket_has_logging(buckets_by_name[ct.s3_bucket_name])
+}
+
+bucket_has_logging(bucket) {
+  _ = bucket.logging[_]
+}
+
+bucket_has_logging(bucket) {
+  _ = lib.bucket_logging_by_bucket[lib.bucket_name_or_id(bucket)]
 }
 
 resource_type := "MULTIPLE"

--- a/rego/rules/tf/aws/cloudtrail/target.rego
+++ b/rego/rules/tf/aws/cloudtrail/target.rego
@@ -46,10 +46,13 @@ cloudtrail_buckets = {bucket_id: bucket |
   lib.bucket_name_or_id(bucket) == ct.s3_bucket_name
 }
 
+public_acls := {"public-read", "public-read-write"}
+
 bucket_public_acl(bucket) {
-  bucket.acl == "public-read"
+  public_acls[bucket.acl]
 } {
-  bucket.acl == "public-read-write"
+  acl := lib.bucket_acls_by_bucket[lib.bucket_name_or_id(bucket)]
+  public_acls[acl.acl]
 }
 
 resource_type := "MULTIPLE"

--- a/rego/rules/tf/aws/kms/key_rotation.rego
+++ b/rego/rules/tf/aws/kms/key_rotation.rego
@@ -40,7 +40,7 @@ resource_type := "MULTIPLE"
 
 keys := fugue.resources("aws_kms_key")
 
-symmetric_key_spec_prefixes := {"HMAC", "SYMMETRIC"}
+symmetric_key_spec_prefixes := {"SYMMETRIC"}
 
 is_symmetric(k) {
   prefix := split(k.customer_master_key_spec, "_")[0]

--- a/rego/rules/tf/aws/s3/bucket_is_public.rego
+++ b/rego/rules/tf/aws/s3/bucket_is_public.rego
@@ -83,6 +83,13 @@ invalid_grant(grants) {
   invalid_grant_uris[grant.uri]
 }
 
+invalid_acl_grant(acl) {
+  grant := acl.access_control_policy[_].grant[_]
+  invalid_permissions[grant.permission]
+  uri := grant.grantee[_].uri
+  invalid_grant_uris[uri]
+}
+
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions
 invalid_actions = {
   "*",
@@ -118,9 +125,17 @@ invalid_bucket_policy(pol) {
 bucket_invalid_reason(b) = concat(" ", [base_message, "An ACL allows public access to the bucket"]) {
   not valid_private_by_block[lib.bucket_name_or_id(b)]
   invalid_canned_acl[b.acl]
+} else = concat(" ", [base_message, "An ACL allows public access to the bucket"]) {
+  not valid_private_by_block[lib.bucket_name_or_id(b)]
+  acl := lib.bucket_acls_by_bucket[lib.bucket_name_or_id(b)]
+  invalid_canned_acl[acl.acl]
 } else = concat(" ", [base_message, "A grant allows public access to the bucket"]) {
   not valid_private_by_block[lib.bucket_name_or_id(b)]
   invalid_grant(b.grant)
+} else = concat(" ", [base_message, "A grant allows public access to the bucket"]) {
+  not valid_private_by_block[lib.bucket_name_or_id(b)]
+  acl := lib.bucket_acls_by_bucket[lib.bucket_name_or_id(b)]
+  invalid_acl_grant(acl)
 } else = concat(" ", [base_message, "A bucket policy allows public access to the bucket"]) {
   not valid_private_by_block[lib.bucket_name_or_id(b)]
   policies = lib.bucket_policies_for_bucket(b)

--- a/rego/tests/rules/tf/aws/kms/key_rotation_test.rego
+++ b/rego/tests/rules/tf/aws/kms/key_rotation_test.rego
@@ -16,7 +16,8 @@ package rules.tf_aws_kms_key_rotation
 import data.tests.rules.tf.aws.kms.inputs.key_rotation_infra_json
 
 test_kms_rotate {
-  resources = key_rotation_infra_json.mock_resources
-  count(deny) == 0 with input as resources["aws_kms_key.valid"]
-  count(deny) == 1 with input as resources["aws_kms_key.invalid"]
+  pol := policy with input as key_rotation_infra_json.mock_input
+  by_resource_id := {p.id: p.valid | pol[p]}
+  by_resource_id["aws_kms_key.valid"] == true
+  by_resource_id["aws_kms_key.invalid"] == false
 }


### PR DESCRIPTION
This PR updates the following rules to support the constructs added in the Terraform AWS Provider v4:

* FG_R00028: S3 bucket ACLs should not have public access on S3 buckets that store CloudTrail log files
* FG_R00031: S3 bucket access logging should be enabled on S3 buckets that store CloudTrail log files
* FG_R00036: KMS CMK rotation should be enabled
* FG_R00044: VPC security group inbound rules should not permit ingress from a public address to all ports and protocols
* FG_R00101: S3 bucket versioning and lifecycle policies should be enabled
* FG_R00252: KMS master keys should not be publicly accessible
* FG_R00274: S3 bucket access logging should be enabled
* FG_R00275: S3 bucket replication (cross-region or same-region) should be enabled
* FG_R00277: S3 buckets should not be publicly readable
* FG_R00279: S3 bucket policies and ACLs should not be configured for public read access
