### PR TITLE
Add docker tags for major and minor version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,8 @@ dockers:
   - image_templates:
     - "fugue/regula:{{ if .Prerelease }}preview{{ else }}latest{{ end }}"
     - "fugue/regula:{{ .Tag }}"
+    - "fugue/regula:v{{ .Major }}{{ if .Prerelease }}-pre{{ end }}"
+    - "fugue/regula:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease }}-pre{{ end }}"
 
 brews:
   - skip_upload: auto


### PR DESCRIPTION
This PR adds two new docker tags to the release process:

* `fugue/regula:v<major>`, e.g. `fugue/regula:v2`
* `fugue/regula:v<major>.<minor>`, e.g. `fugue/regula:v2.7`

For pre-release git tags, these new docker tags will be suffixed with `-pre`, e.g. `fugue/regula:v2-pre`.