### PR TITLE
[CLOUD-266] tfvars support

### DIFF
--- a/changes/unreleased/Added-20220614-094302.yaml
+++ b/changes/unreleased/Added-20220614-094302.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Support for tfvars files and a corresponding `--var-file` option. See the [usage
+  section of our docs site](https://regula.dev/usage.html#variable-support) for a
+  description of this feature. (#343)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -44,6 +44,7 @@ const syncFlag = "sync"
 const uploadFlag = "upload"
 const excludeFlag = "exclude"
 const onlyFlag = "only"
+const varFileFlag = "var-file"
 
 const inputTypeDescriptions = `
 Input types:
@@ -152,6 +153,11 @@ func addExcludeFlag(cmd *cobra.Command, v *viper.Viper) {
 func addOnlyFlag(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().StringSliceP(onlyFlag, "o", nil, "Rule IDs or names to run. All other rules will be excluded. Can be specified multiple times.")
 	v.BindPFlag(onlyFlag, cmd.Flags().Lookup(onlyFlag))
+}
+
+func addVarFileFlag(cmd *cobra.Command, v *viper.Viper) {
+	cmd.Flags().StringSlice(varFileFlag, nil, "Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.")
+	v.BindPFlag(varFileFlag, cmd.Flags().Lookup(varFileFlag))
 }
 
 func joinDescriptions(descriptions ...string) string {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -156,7 +156,7 @@ func addOnlyFlag(cmd *cobra.Command, v *viper.Viper) {
 }
 
 func addVarFileFlag(cmd *cobra.Command, v *viper.Viper) {
-	cmd.Flags().StringSlice(varFileFlag, nil, "Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.")
+	cmd.Flags().StringSlice(varFileFlag, nil, "Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code. Can be specified multiple times.")
 	v.BindPFlag(varFileFlag, cmd.Flags().Lookup(varFileFlag))
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,6 +73,9 @@ func NewInitCommand() *cobra.Command {
 			if err := configureBoolIfSet(cmd, v, syncFlag); err != nil {
 				return err
 			}
+			if err := configureStringSliceIfSet(cmd, v, varFileFlag); err != nil {
+				return err
+			}
 			if len(paths) > 0 {
 				v.Set(inputsFlag, paths)
 			}
@@ -120,6 +123,7 @@ func NewInitCommand() *cobra.Command {
 	addOnlyFlag(cmd, v)
 	addSeverityFlag(cmd, v)
 	addSyncFlag(cmd, v)
+	addVarFileFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fugue/regula/v2/pkg/rego"
 	"github.com/fugue/regula/v2/pkg/loader"
+	"github.com/fugue/regula/v2/pkg/rego"
 	"github.com/fugue/regula/v2/pkg/reporter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -112,6 +112,7 @@ func NewRunCommand() *cobra.Command {
 				severity:      severity,
 				sync:          v.GetBool(syncFlag),
 				upload:        upload,
+				varFiles:      v.GetStringSlice(varFileFlag),
 			}
 			if err := config.Validate(); err != nil {
 				return err
@@ -173,6 +174,7 @@ func NewRunCommand() *cobra.Command {
 	addSeverityFlag(cmd, v)
 	addSyncFlag(cmd, v)
 	addUploadFlag(cmd)
+	addVarFileFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/cmd/runconfig.go
+++ b/cmd/runconfig.go
@@ -43,6 +43,7 @@ type runConfig struct {
 	severity      reporter.Severity
 	sync          bool
 	upload        bool
+	varFiles      []string
 }
 
 func (c *runConfig) Validate() error {
@@ -105,6 +106,7 @@ func (c *runConfig) ConfigurationLoader() (loader.ConfigurationLoader, error) {
 		Paths:       c.inputs,
 		InputTypes:  inputTypes,
 		NoGitIgnore: c.noIgnore,
+		VarFiles:    c.varFiles,
 	}), nil
 }
 

--- a/cmd/showinput.go
+++ b/cmd/showinput.go
@@ -34,11 +34,13 @@ func NewShowInputCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			varFiles := v.GetStringSlice(varFileFlag)
 			// Silence usage now that we're past arg parsing
 			cmd.SilenceUsage = true
 			loadedFiles, err := loader.LocalConfigurationLoader(loader.LoadPathsOptions{
 				Paths:      paths,
 				InputTypes: inputTypes,
+				VarFiles:   varFiles,
 			})()
 			if err != nil {
 				return err
@@ -53,6 +55,7 @@ func NewShowInputCommand() *cobra.Command {
 	}
 
 	addInputTypeFlag(cmd, v)
+	addVarFileFlag(cmd, v)
 	cmd.Flags().SetNormalizeFunc(normalizeFlag)
 	return cmd
 }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -161,6 +161,7 @@ Regula can use an optional `.regula.yaml` configuration file to set some default
   -o, --only strings            Rule IDs or names to run. All other rules will be excluded. Can be specified multiple times.
   -s, --severity string         Set the minimum severity that will result in a non-zero exit code. (default "unknown")
       --sync                    Fetch rules and configuration from Fugue
+      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.
 ```
 
 To create the configuration file, run `regula init [input...] [flags]`. An easy way to setup the configuration file is to use `regula run` to figure out which options you want to set:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -161,7 +161,7 @@ Regula can use an optional `.regula.yaml` configuration file to set some default
   -o, --only strings            Rule IDs or names to run. All other rules will be excluded. Can be specified multiple times.
   -s, --severity string         Set the minimum severity that will result in a non-zero exit code. (default "unknown")
       --sync                    Fetch rules and configuration from Fugue
-      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.
+      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code. Can be specified multiple times.
 ```
 
 To create the configuration file, run `regula init [input...] [flags]`. An easy way to setup the configuration file is to use `regula run` to figure out which options you want to set:

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -53,7 +53,7 @@ Flags:
   -s, --severity string         Set the minimum severity that will result in a non-zero exit code. (default "unknown")
       --sync                    Fetch rules and configuration from Fugue
       --upload                  Upload rule results to Fugue
-      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.
+      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code. Can be specified multiple times.
 
 Global Flags:
   -v, --verbose   verbose output

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -53,6 +53,7 @@ Flags:
   -s, --severity string         Set the minimum severity that will result in a non-zero exit code. (default "unknown")
       --sync                    Fetch rules and configuration from Fugue
       --upload                  Upload rule results to Fugue
+      --var-file strings        Paths to .tfvars or .json files to be used while evaluating Terraform HCL source code.
 
 Global Flags:
   -v, --verbose   verbose output
@@ -127,6 +128,24 @@ terraform show -json plan.tfplan | regula run
 
 !!! note
     Regula can only evaluate Terraform modules that are available locally. If your Terraform configuration depends on external modules (for example from the Terraform module registry or GitHub) and you want to evaluate resources from those modules, run `terraform init` before running Regula. `terraform init` will download all external modules to a `.terraform` directory and Regula will be able to resolve them.
+
+##### Variable support
+
+The `run` command has a `--var-file` option which you can use to specify Terraform variable files that should be used during evaluation. For example:
+
+```sh
+regula run --var-file prod.tfvars my_tf_infra
+```
+
+Regula will also automatically load `terraform.tfvars`, `*.auto.tfvars` and their JSON equivalents when found. We follow the same order of preference described in the [Variable Definition Precedence](https://www.terraform.io/language/values/variables#variable-definition-precedence) section of the Terraform documentation with the caveats that Regula **does not** currently support Terraform variables in environment variables nor does it have an analog of Terraform's `-var` option. With those caveats in mind, Regula follows this order of precedence to resolve variable values, with later sources taking precedence over earlier ones:
+
+* Any default values specified in the variable declarations
+* The `terraform.tfvars` file, if present.
+* The `terraform.tfvars.json` file, if present.
+* Any `*.auto.tfvars` or `*.auto.tfvars.json` files, processed in lexical order of their filenames
+* Any `--var-file` options on the command line, in the order they are provided
+
+If Regula does not have any possible values for a variable, that variable will evaluate to `null`.
 
 #### CloudFormation input
 

--- a/pkg/loader/base.go
+++ b/pkg/loader/base.go
@@ -163,6 +163,7 @@ func (l Location) String() string {
 type DetectOptions struct {
 	IgnoreExt  bool
 	IgnoreDirs bool
+	VarFiles   []string
 }
 
 // ConfigurationDetector implements the visitor part of the visitor pattern for the

--- a/pkg/loader/loadpaths.go
+++ b/pkg/loader/loadpaths.go
@@ -31,6 +31,7 @@ type LoadPathsOptions struct {
 	InputTypes  []InputType
 	NoGitIgnore bool
 	IgnoreDirs  bool
+	VarFiles    []string
 }
 
 type NoLoadableConfigsError struct {
@@ -67,6 +68,7 @@ func LocalConfigurationLoader(options LoadPathsOptions) ConfigurationLoader {
 			loader, _ := i.DetectType(detector, DetectOptions{
 				IgnoreExt:  false,
 				IgnoreDirs: options.IgnoreDirs,
+				VarFiles:   options.VarFiles,
 			})
 			if loader != nil {
 				configurations.AddConfiguration(i.Path(), loader)
@@ -87,6 +89,7 @@ func LocalConfigurationLoader(options LoadPathsOptions) ConfigurationLoader {
 				i := newFile(stdIn, stdIn)
 				loader, err := i.DetectType(detector, DetectOptions{
 					IgnoreExt: true,
+					VarFiles:  options.VarFiles,
 				})
 				if err != nil {
 					return nil, err
@@ -124,6 +127,7 @@ func LocalConfigurationLoader(options LoadPathsOptions) ConfigurationLoader {
 				loader, err := i.DetectType(detector, DetectOptions{
 					IgnoreExt:  ignoreFileExtension,
 					IgnoreDirs: options.IgnoreDirs,
+					VarFiles:   options.VarFiles,
 				})
 				if err != nil {
 					return nil, err
@@ -138,6 +142,7 @@ func LocalConfigurationLoader(options LoadPathsOptions) ConfigurationLoader {
 				i := newFile(path, name)
 				loader, err := i.DetectType(detector, DetectOptions{
 					IgnoreExt: ignoreFileExtension,
+					VarFiles:  options.VarFiles,
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -45,7 +45,7 @@ func (t *TfDetector) DetectFile(i InputFile, opts DetectOptions) (IACConfigurati
 		}
 	}
 
-	moduleTree, err := regulatf.ParseFiles(nil, inputFs, false, dir, []string{i.Path()}, []string{})
+	moduleTree, err := regulatf.ParseFiles(nil, inputFs, false, dir, []string{i.Path()}, opts.VarFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (t *TfDetector) DetectDirectory(i InputDirectory, opts DetectOptions) (IACC
 	}
 
 	moduleRegister := regulatf.NewTerraformRegister(i.Path())
-	moduleTree, err := regulatf.ParseDirectory(moduleRegister, nil, i.Path())
+	moduleTree, err := regulatf.ParseDirectory(moduleRegister, nil, i.Path(), opts.VarFiles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loader/tf.go
+++ b/pkg/loader/tf.go
@@ -45,7 +45,7 @@ func (t *TfDetector) DetectFile(i InputFile, opts DetectOptions) (IACConfigurati
 		}
 	}
 
-	moduleTree, err := regulatf.ParseFiles(nil, inputFs, false, dir, []string{i.Path()})
+	moduleTree, err := regulatf.ParseFiles(nil, inputFs, false, dir, []string{i.Path()}, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loader/tf_test/tfvars-01.json
+++ b/pkg/loader/tf_test/tfvars-01.json
@@ -1,0 +1,30 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.bucket": {
+        "_filepath": "tf_test/tfvars-01/main.tf",
+        "_provider": "aws",
+        "_tags": {
+          "var_1": "default_value",
+          "var_2": "hi I am in terraform.tfvars",
+          "var_3": "hey I'm in terraform.tfvars.json",
+          "var_4": "Hey I'm in aaa",
+          "var_5": "Hey I'm in bbb",
+          "var_6": "Hey I'm in ccc"
+        },
+        "_type": "aws_s3_bucket",
+        "id": "aws_s3_bucket.bucket",
+        "tags": {
+          "var_1": "default_value",
+          "var_2": "hi I am in terraform.tfvars",
+          "var_3": "hey I'm in terraform.tfvars.json",
+          "var_4": "Hey I'm in aaa",
+          "var_5": "Hey I'm in bbb",
+          "var_6": "Hey I'm in ccc"
+        }
+      }
+    }
+  },
+  "filepath": "tf_test/tfvars-01"
+}

--- a/pkg/loader/tf_test/tfvars-01/aaa.auto.tfvars
+++ b/pkg/loader/tf_test/tfvars-01/aaa.auto.tfvars
@@ -1,0 +1,3 @@
+in_aaa_auto_tfvars = "Hey I'm in aaa"
+in_bbb_auto_tfvars_json = "I will be overridden :-("
+in_ccc_auto_tfvars = "I will be overridden :-("

--- a/pkg/loader/tf_test/tfvars-01/bbb.auto.tfvars.json
+++ b/pkg/loader/tf_test/tfvars-01/bbb.auto.tfvars.json
@@ -1,0 +1,3 @@
+{
+    "in_bbb_auto_tfvars_json": "Hey I'm in bbb"
+}

--- a/pkg/loader/tf_test/tfvars-01/ccc.auto.tfvars
+++ b/pkg/loader/tf_test/tfvars-01/ccc.auto.tfvars
@@ -1,0 +1,1 @@
+in_ccc_auto_tfvars = "Hey I'm in ccc"

--- a/pkg/loader/tf_test/tfvars-01/main.tf
+++ b/pkg/loader/tf_test/tfvars-01/main.tf
@@ -1,0 +1,40 @@
+variable "using_default" {
+    type = string
+    default = "default_value"
+}
+
+variable "in_terraform_tfvars" {
+    type = string
+    default = "default_value"
+}
+
+variable "in_terraform_tfvars_json" {
+    type = string
+    default = "default_value"
+}
+
+variable "in_aaa_auto_tfvars" {
+    type = string
+    default = "default_value"
+}
+
+variable "in_bbb_auto_tfvars_json" {
+    type = string
+    default = "default_value"
+}
+
+variable "in_ccc_auto_tfvars" {
+    type = string
+    default = "default_value"
+}
+
+resource "aws_s3_bucket" "bucket" {
+    tags = {
+        var_1 = var.using_default
+        var_2 = var.in_terraform_tfvars
+        var_3 = var.in_terraform_tfvars_json
+        var_4 = var.in_aaa_auto_tfvars
+        var_5 = var.in_bbb_auto_tfvars_json
+        var_6 = var.in_ccc_auto_tfvars
+    }
+}

--- a/pkg/loader/tf_test/tfvars-01/terraform.tfvars
+++ b/pkg/loader/tf_test/tfvars-01/terraform.tfvars
@@ -1,0 +1,3 @@
+in_terraform_tfvars = "hi I am in terraform.tfvars"
+in_terraform_tfvars_json = "i will be overridden :-("
+in_aaa_auto_tfvars = "i will be overridden :-("

--- a/pkg/loader/tf_test/tfvars-01/terraform.tfvars.json
+++ b/pkg/loader/tf_test/tfvars-01/terraform.tfvars.json
@@ -1,0 +1,6 @@
+{
+    "in_terraform_tfvars_json": "hey I'm in terraform.tfvars.json",
+    "in_aaa_auto_tfvars": "i will be overridden :-(",
+    "in_bbb_auto_tfvars_json": "i will be overridden :-(",
+    "in_ccc_auto_tfvars": "i will be overridden :-("
+}

--- a/pkg/loader/tf_test/tfvars-02.json
+++ b/pkg/loader/tf_test/tfvars-02.json
@@ -1,0 +1,24 @@
+{
+  "content": {
+    "hcl_resource_view_version": "0.0.1",
+    "resources": {
+      "aws_s3_bucket.bucket": {
+        "_filepath": "tf_test/tfvars-02/main.tf",
+        "_provider": "aws",
+        "_tags": {
+          "booly": "yes",
+          "listy": "Hello",
+          "mappy": "value"
+        },
+        "_type": "aws_s3_bucket",
+        "id": "aws_s3_bucket.bucket",
+        "tags": {
+          "booly": "yes",
+          "listy": "Hello",
+          "mappy": "value"
+        }
+      }
+    }
+  },
+  "filepath": "tf_test/tfvars-02"
+}

--- a/pkg/loader/tf_test/tfvars-02/main.tf
+++ b/pkg/loader/tf_test/tfvars-02/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+    region = "us-east-1"
+}
+
+variable "booly" {
+    type = bool
+}
+
+variable "listy" {
+    type = list(string)
+}
+
+variable "mappy" {
+    type = map(string)
+}
+
+resource "aws_s3_bucket" "bucket" {
+    tags = {
+        booly = var.booly ? "yes" : "no"
+        listy = var.listy[0]
+        mappy = var.mappy["key"]
+    }
+}

--- a/pkg/loader/tf_test/tfvars-02/terraform.tfvars
+++ b/pkg/loader/tf_test/tfvars-02/terraform.tfvars
@@ -1,0 +1,5 @@
+booly = true
+listy = ["Hello", "world"]
+mappy = {
+    "key": "value"
+}

--- a/pkg/regulatf/names.go
+++ b/pkg/regulatf/names.go
@@ -184,17 +184,17 @@ func (name FullName) AsModuleInput() *FullName {
 	return nil
 }
 
-// Parses "var.my_var" into "variable.my_var"
-func (name FullName) AsDefault() *FullName {
+// Parses "var.my_var.key" into "variable.my_var", "var.my_var" and "key".
+func (name FullName) AsVariable() (*FullName, *FullName, LocalName) {
 	if len(name.Local) >= 2 {
 		if str, ok := name.Local[0].(string); ok && str == "var" {
 			local := make(LocalName, len(name.Local))
 			copy(local, name.Local)
 			local[0] = "variable"
-			return &FullName{name.Module, local}
+			return &FullName{name.Module, local[:2]}, &FullName{name.Module, name.Local[:2]}, local[2:]
 		}
 	}
-	return nil
+	return nil, nil, nil
 }
 
 // Parses "aws_s3_bucket.my_bucket[3].bucket_prefix" into:

--- a/pkg/regulatf/regulatf.go
+++ b/pkg/regulatf/regulatf.go
@@ -98,7 +98,7 @@ func (v *Analysis) dependencies(name FullName, expr hcl.Expression) []dependency
 		} else if moduleOutput := full.AsModuleOutput(); moduleOutput != nil {
 			// Rewrite module outputs.
 			deps = append(deps, dependency{full, moduleOutput, nil})
-		} else if asDefault := full.AsDefault(); asDefault != nil {
+		} else if asVariable, asVar, _ := full.AsVariable(); asVar != nil {
 			// Rewrite variables either as default, or as module input.
 			asModuleInput := full.AsModuleInput()
 			isModuleInput := false
@@ -109,7 +109,7 @@ func (v *Analysis) dependencies(name FullName, expr hcl.Expression) []dependency
 				}
 			}
 			if !isModuleInput {
-				deps = append(deps, dependency{full, asDefault, nil})
+				deps = append(deps, dependency{*asVar, asVariable, nil})
 			}
 		} else if asResourceName, _, trailing := full.AsResourceName(); asResourceName != nil {
 			// Rewrite resource references.

--- a/pkg/regulatf/varfiles.go
+++ b/pkg/regulatf/varfiles.go
@@ -1,0 +1,41 @@
+package regulatf
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/afero"
+)
+
+func findVarFiles(fs afero.Fs, dir string) ([]string, error) {
+	if fs == nil {
+		fs = afero.OsFs{}
+	}
+
+	// We want to sort files by basename.  The spec is:
+	//
+	//  -  Environment variables
+	//  -  The terraform.tfvars file, if present.
+	//  -  The terraform.tfvars.json file, if present.
+	//  -  Any *.auto.tfvars or *.auto.tfvars.json files, processed in lexical
+	//     order of their filenames.
+	//  -  -var and -var-file options on the command line, in the order they are
+	//     provided. (This includes variables set by Terraform Cloud workspace.)
+	//
+	// Source: <https://www.terraform.io/language/values/variables#variable-definition-precedence>
+	globs := []string{
+		filepath.Join(dir, "terraform.tfvars"),
+		filepath.Join(dir, "terraform.tfvars.json"),
+		filepath.Join(dir, "*.auto.tfvars"),
+		filepath.Join(dir, "*.auto.tfvars.json"),
+	}
+	matches := []string{}
+	for _, glob := range globs {
+		m, err := afero.Glob(fs, glob)
+		if err != nil {
+			return matches, err
+		}
+		matches = append(sort.StringSlice(matches), m...)
+	}
+	return matches, nil
+}


### PR DESCRIPTION
This PR adds support for tfvars files. After this change, Regula will automatically load `terraform.tfvars`, `*.auto.tfvars`, and their JSON equivalents. Users will also have the option to manually specify tfvars files (and their JSON equivalents) with the `--var-file` option, which can be specified more than once.