### PR TITLE
Added support for remediation doc to regotools metadoc

### DIFF
--- a/pkg/regotools/metadoc/metadoc.go
+++ b/pkg/regotools/metadoc/metadoc.go
@@ -44,13 +44,14 @@ type RegoMeta struct {
 	metadocEndLine   int                    // End of metadoc, -1 if not present
 	metadoc          map[string]interface{} // Dynamic metadoc
 
-	Id          string
-	Title       string
-	Description string
-	Severity    string
-	Controls    map[string][]string
-	Families    []string
-	Providers   []string
+	Id                 string
+	Title              string
+	Description        string
+	Severity           string
+	Controls           map[string][]string
+	Families           []string
+	Providers          []string
+	RuleRemediationDoc string
 
 	ResourceType     string // Resource type
 	resourceTypeLine int
@@ -74,11 +75,12 @@ func RegoMetaFromPath(path string) (*RegoMeta, error) {
 }
 
 type metadocCustom struct {
-	Severity  string              `json:"severity"`
-	Controls  map[string][]string `json:"controls"`
-	Families  []string            `json:"families"`
-	Provider  string              `json:"provider"`
-	Providers []string            `json:"providers"`
+	Severity           string              `json:"severity"`
+	Controls           map[string][]string `json:"controls"`
+	Families           []string            `json:"families"`
+	Provider           string              `json:"provider"`
+	Providers          []string            `json:"providers"`
+	RuleRemediationDoc string              `json:"rule_remediation_doc"`
 }
 
 type metadoc struct {
@@ -193,6 +195,7 @@ func RegoMetaFromString(str string) (*RegoMeta, error) {
 			rego.Severity = metadoc.Custom.Severity
 			rego.Families = metadoc.Custom.Families
 			rego.Providers = metadoc.Custom.Providers
+			rego.RuleRemediationDoc = metadoc.Custom.RuleRemediationDoc
 
 			// Migrate old provider field.
 			if len(rego.Providers) == 0 && len(metadoc.Custom.Provider) != 0 {

--- a/pkg/regotools/metadoc/metadoc_test.go
+++ b/pkg/regotools/metadoc/metadoc_test.go
@@ -80,7 +80,8 @@ __rego__metadoc__ := {
       "MyCustomFamily",
       "1172ca4f-6d31-4c46-a085-54ff73c6ed27"
     ],
-    "provider": "AWS"
+    "provider": "AWS",
+    "rule_remediation_doc": "https://example.com/remediationdoc",
   },
   "description": "EBS volume encryption should be enabled. Enabling encryption on EBS volumes protects data at rest inside the volume, data in transit between the volume and the instance, snapshots created from the volume, and volumes created from those snapshots. EBS volumes are encrypted using KMS keys.",
   "id": "FG_R00016",
@@ -113,6 +114,7 @@ allow {
 					},
 					rego.Controls)
 				assert.Equal(t, []string{"AWS"}, rego.Providers)
+				assert.Equal(t, "https://example.com/remediationdoc", rego.RuleRemediationDoc)
 
 				rego.Description = "Updated description"
 				rego.Severity = "Low"
@@ -139,6 +141,7 @@ __rego__metadoc__ := {
       "AZURE",
       "REPOSITORY"
     ],
+    "rule_remediation_doc": "https://example.com/remediationdoc",
     "severity": "Low"
   },
   "description": "Updated description",


### PR DESCRIPTION
This PR is related to https://github.com/fugue/regula/pull/247.

As part of metadoc, we can specify custom remediation doc link for custom rule. This PR makes it so that regotools support that as well when processing metadoc.